### PR TITLE
Fixed metadata for ECO data set

### DIFF
--- a/nilmtk/dataset_converters/eco/metadata/building1.yaml
+++ b/nilmtk/dataset_converters/eco/metadata/building1.yaml
@@ -10,10 +10,8 @@ original_name: house_1
 elec_meters:
   1: &smart_meter
     site_meter: true
-    submeter_of: 0
     device_model: smart_meter
   2: &plug
-    site_meter: true
     submeter_of: 0
     device_model: plug
   3: *plug

--- a/nilmtk/dataset_converters/eco/metadata/building2.yaml
+++ b/nilmtk/dataset_converters/eco/metadata/building2.yaml
@@ -10,10 +10,8 @@ original_name: house_2
 elec_meters:
   1: &smart_meter
     site_meter: true
-    submeter_of: 0
     device_model: smart_meter
   2: &plug
-    site_meter: true
     submeter_of: 0
     device_model: plug
   3: *plug

--- a/nilmtk/dataset_converters/eco/metadata/building3.yaml
+++ b/nilmtk/dataset_converters/eco/metadata/building3.yaml
@@ -10,10 +10,8 @@ original_name: house_3
 elec_meters:
   1: &smart_meter
     site_meter: true
-    submeter_of: 0
     device_model: smart_meter
   2: &plug
-    site_meter: true
     submeter_of: 0
     device_model: plug
   3: *plug

--- a/nilmtk/dataset_converters/eco/metadata/building4.yaml
+++ b/nilmtk/dataset_converters/eco/metadata/building4.yaml
@@ -10,10 +10,8 @@ original_name: house_4
 elec_meters:
   1: &smart_meter
     site_meter: true
-    submeter_of: 0
     device_model: smart_meter
   2: &plug
-    site_meter: true
     submeter_of: 0
     device_model: plug
   3: *plug

--- a/nilmtk/dataset_converters/eco/metadata/building5.yaml
+++ b/nilmtk/dataset_converters/eco/metadata/building5.yaml
@@ -10,10 +10,8 @@ original_name: house_5
 elec_meters:
   1: &smart_meter
     site_meter: true
-    submeter_of: 0
     device_model: smart_meter
   2: &plug
-    site_meter: true
     submeter_of: 0
     device_model: plug
   3: *plug

--- a/nilmtk/dataset_converters/eco/metadata/building6.yaml
+++ b/nilmtk/dataset_converters/eco/metadata/building6.yaml
@@ -10,10 +10,8 @@ original_name: house_6
 elec_meters:
   1: &smart_meter
     site_meter: true
-    submeter_of: 0
     device_model: smart_meter
   2: &plug
-    site_meter: true
     submeter_of: 0
     device_model: plug
   3: *plug

--- a/nilmtk/dataset_converters/eco/metadata/dataset.yaml
+++ b/nilmtk/dataset_converters/eco/metadata/dataset.yaml
@@ -15,8 +15,7 @@ subject: >
 number_of_buildings: 6
 timezone: CET
 geo_location:
-  country: Sweden  # standard two-letter country code defined by ISO 3166-1 alpha-2
-  latitude: 59.35
-  longitude: 18.07
-related_documents:
+  country: CH  # standard two-letter country code defined by ISO 3166-1 alpha-2
+  latitude: 46.757
+  longitude: 7.61333related_documents:
 - http://www.vs.inf.ethz.ch/publ/papers/beckel-2014-nilm.pdf


### PR DESCRIPTION
You're exactly right: the plugs should not be marked as site_meter:true and the smart_meter should not be marked as 'submeter_of':0. Can you issue a pull request for these changes?

@oliparson Done :)
