### PR TITLE
ECO data set converter works now - open issues to be discussed

### DIFF
--- a/nilmtk/dataset_converters/eco/convert_eco.py
+++ b/nilmtk/dataset_converters/eco/convert_eco.py
@@ -26,10 +26,10 @@ Each folder has a CSV file as per each day, with each day csv file containing
 	86400 entries.
 """
 
-sm_column_name = {1:('power', 'apparent'),
-					2:('power', 'apparent'),
-					3:('power', 'apparent'),
-					4:('power', 'apparent'),
+sm_column_name = {1:('power', 'active'),
+					2:('power', 'active'),
+					3:('power', 'active'),
+					4:('power', 'active'),
 					5:('current', ''),
 					6:('current', ''),
 					7:('current', ''),
@@ -37,88 +37,96 @@ sm_column_name = {1:('power', 'apparent'),
 					9:('voltage', ''),
 					10:('voltage', ''),
 					11:('voltage', ''),
-					12:('phase angle', 'apparent'), #What property to assign to the phase angle?
-					13:('phase angle', 'apparent'),
-					14:('phase angle', 'apparent'),
-					15:('phase angle', 'apparent'),
-					16:('phase angle', 'apparent'),
+					12:('phase_angle', ''),
+					13:('phase_angle', ''),
+					14:('phase_angle', ''),
+					15:('phase_angle', ''),
+					16:('phase_angle', ''),
 					};
 
-plugs_column_name = {1:('power', 'apparent'),	
-					};
+plugs_column_name = {1:('power', 'active'),
+                    };
 
 def convert_eco(dataset_loc, hdf_filename, timezone):
-	"""
-	Parameters:
-	-----------
-	dataset_loc: str
-		The root directory where the dataset is located.
-	hdf_filename: str
-		The location where the hdf_filename is present. 
-                The directory location has to contain the 
-		hdf5file name for the converter to work.
-	timezone: str
-		specifies the timezone of the dataset.
-	"""
+    """
+    Parameters:
+    -----------
+    dataset_loc: str
+        The root directory where the dataset is located.
+    hdf_filename: str
+        The location where the hdf_filename is present. 
+        The directory location has to contain the 
+        hdf5file name for the converter to work.
+    timezone: str
+        specifies the timezone of the dataset.
+    """
 
-	# Creating a new HDF File
-	store = pd.HDFStore(hdf_filename, 'w')
-
+    # Creating a new HDF File
+    store = pd.HDFStore(hdf_filename, 'w')
+    
     check_directory_exists(dataset_loc)
-	directory_list = [i for i in listdir(dataset_loc) if '.txt' not in i]
-	directory_list.sort()
-	print directory_list
+    directory_list = [i for i in listdir(dataset_loc) if '.txt' not in i]
+    directory_list.sort()
+    print directory_list
 
-	# Traversing every folder
-	for folder in directory_list:
+    # Traversing every folder
+    for folder in directory_list:
 
-		if folder[0] == '.' or folder[-3:] == '.h5':
-			print 'Skipping folder ', folder
-			continue
-		print 'Computing for folder',folder
+        if folder[0] == '.' or folder[-3:] == '.h5':
+            print 'Skipping ', folder
+            continue
+        print 'Computing for folder',folder
 
-		#Building number and meter_flag
-		building_no = int(folder[:2])
-		meter_flag = 'sm' if 'sm_csv' in folder else 'plugs'
+        #Building number and meter_flag
+        building_no = int(folder[:2])
+        meter_flag = 'sm' if 'sm_csv' in folder else 'plugs'
 
-		dir_list = [i for i in listdir(join(dataset_loc, folder)) if isdir(join(dataset_loc,folder,i))]
-		dir_list.sort()
-		print 'Current dir list:',dir_list
+        dir_list = [i for i in listdir(join(dataset_loc, folder)) if isdir(join(dataset_loc,folder,i))]
+        dir_list.sort()
+        print 'Current dir list:',dir_list
 
-		for fl in dir_list:
-			#Meter number to be used in key
-			meter_num = 1 if meter_flag == 'sm' else int(fl) + 1
+        for fl in dir_list:
+            #Meter number to be used in key
+            meter_num = 1 if meter_flag == 'sm' else int(fl) + 1
 
-			print 'Computing for Meter no.',meter_num
+            print 'Computing for Meter no.',meter_num
 
-			fl_dir_list = [i for i in listdir(join(dataset_loc,folder,fl)) if '.csv' in i]
-			fl_dir_list.sort()
+            # if meter_num != 4:
+            #     continue
 
-			key = Key(building=building_no, meter=meter_num)
+            fl_dir_list = [i for i in listdir(join(dataset_loc,folder,fl)) if '.csv' in i]
+            fl_dir_list.sort()
 
-			for fi in fl_dir_list:
+            # import ipdb
+            # ipdb.set_trace()
 
-				#Getting dataframe for each csv file seperately
-				df_fl = _get_df(join(dataset_loc,folder,fl),fi,meter_flag)
-				df_fl.sort_index(ascending=True,inplace=True)
-				df_fl = df_fl.tz_convert(timezone)
+            key = str(Key(building=building_no, meter=meter_num))
 
-				# If table not present in hdf5, create or else append to existing data
-				if not key in store:
-					store.put(str(key), df_fl, format='Table')
-				else:
-					store.append(str(key), df_fl, format='Table')
-				store.flush()
-				print 'Building',building_no,', Meter no.',meter_num,'=> Done for ',fi[:-4]
+            for fi in fl_dir_list:
 
-	print "Data storage completed."
-	store.close()
+                #Getting dataframe for each csv file seperately
+                df_fl = _get_df(join(dataset_loc,folder,fl),fi,meter_flag)
+                # The ECO data set is already sorted by time
+                # df_fl.sort_index(ascending=True,inplace=True)
+                df_fl = df_fl.tz_convert(timezone)
 
-	# Adding the metadata to the HDF5file
-	print "Proceeding to Metadata conversion..."
-	meta_path = join(_get_module_directory(), 'metadata')
-	convert_yaml_to_hdf5(meta_path, hdf_filename)
-	print "Completed Metadata conversion."
+                # If table not present in hdf5, create or else append to existing data
+                if not key in store:
+                    store.put(key, df_fl, format='Table')
+                    print 'Building',building_no,', Meter no.',meter_num,'=> Done for ',fi[:-4]
+                else:
+                    store.append(key, df_fl, format='Table')
+                    store.flush()
+                    print 'Building',building_no,', Meter no.',meter_num,'=> Done for ',fi[:-4]
+
+    print "Data storage completed."
+    store.close()
+
+    # Adding the metadata to the HDF5file
+    print "Proceeding to Metadata conversion..."
+    meta_path = join(_get_module_directory(), 'metadata')
+    convert_yaml_to_hdf5(meta_path, hdf_filename)
+    print "Completed Metadata conversion."
 
 def _get_module_directory():
     # Taken from http://stackoverflow.com/a/6098238/732596
@@ -134,26 +142,26 @@ def _get_module_directory():
     return path_to_this_file
 
 def _get_df(dir_loc, csv_name, meter_flag):
-	"""
-	Parameters
-	----------
-	dir_loc: str
-		Location of the directory containing the csv file.
-	csv_name: str
-		Name of the .csv file whose values are being read.
-	meter_flag: str
-		Used to differentiate between a Smart Meter and a Plug file.
-	"""
-	
-	# Changing column length for Smart Meters and Plugs
-	column_num = 16 if meter_flag == 'sm' else 1
+    """
+    Parameters
+    ----------
+    dir_loc: str
+        Location of the directory containing the csv file.
+    csv_name: str
+        Name of the .csv file whose values are being read.
+    meter_flag: str
+        Used to differentiate between a Smart Meter and a Plug file.
+    """
 
-	# Reading the CSV file and adding a datetime64 index to the Dataframe
-	df = pd.read_csv(join(dir_loc,csv_name), names=[i for i in range(1,column_num+1)])
-	df.index = pd.DatetimeIndex(start=csv_name[:-4], freq='s', periods=86400, tz = 'GMT')
+    # Changing column length for Smart Meters and Plugs
+    column_num = 16 if meter_flag == 'sm' else 1
 
-	if meter_flag == 'sm':
-		df.rename(columns=sm_column_name, inplace=True)
-	else:
-		df.rename(columns=plugs_column_name, inplace=True)
-	return df
+    # Reading the CSV file and adding a datetime64 index to the Dataframe
+    df = pd.read_csv(join(dir_loc,csv_name), names=[i for i in range(1,column_num+1)], dtype=np.float64)
+    df.index = pd.DatetimeIndex(start=csv_name[:-4], freq='s', periods=86400, tz = 'GMT')
+
+    if meter_flag == 'sm':
+        df.rename(columns=sm_column_name, inplace=True)
+    else:
+        df.rename(columns=plugs_column_name, inplace=True)
+    return df

--- a/nilmtk/dataset_converters/eco/metadata/building1.yaml
+++ b/nilmtk/dataset_converters/eco/metadata/building1.yaml
@@ -9,8 +9,8 @@ original_name: house_1
 
 elec_meters:
   1: &smart_meter
-    site_meter: true
     device_model: smart_meter
+    site_meter: true
   2: &plug
     submeter_of: 0
     device_model: plug
@@ -70,3 +70,7 @@ appliances:
   instance: 1
   #coverage: 98.53
   meters: [8] #Plug number
+  
+time_frame:
+  start: 2012-06-01
+  end: 2013-01-31

--- a/nilmtk/dataset_converters/eco/metadata/building2.yaml
+++ b/nilmtk/dataset_converters/eco/metadata/building2.yaml
@@ -27,12 +27,12 @@ elec_meters:
   13: *plug
 
 appliances:
-- original_name: Laptop and Tablet
-  type: laptop computer
+- original_name: Tablet
+  type: tablet computer charger
   #days_covered: 240
   instance: 1
   #coverage: 97.43
-  meters: [2,10] #Plug number
+  meters: [2] #Plug number
 
 - original_name: Dishwasher
   type: dish washer
@@ -83,6 +83,13 @@ appliances:
   #coverage: 90.21
   meters: [9] #Plug number
 
+- original_name: Laptops
+  type: laptop computer
+  #days_covered: 240
+  instance: 1
+  #coverage: 83.36
+  meters: [10] #Plug number
+  
 - original_name: Stove
   type: stove
   #days_covered: 28
@@ -103,3 +110,8 @@ appliances:
   instance: 1
   #coverage: 95.95
   meters: [13] #Plug number
+  
+time_frame:
+  start: 2012-06-01
+  end: 2013-01-31
+  

--- a/nilmtk/dataset_converters/eco/metadata/building3.yaml
+++ b/nilmtk/dataset_converters/eco/metadata/building3.yaml
@@ -70,3 +70,8 @@ appliances:
   instance: 1
   #coverage: 67.65
   meters: [8] #Plug number
+  
+time_frame:
+  start: 2012-07-26
+  end: 2013-01-31
+  

--- a/nilmtk/dataset_converters/eco/metadata/building4.yaml
+++ b/nilmtk/dataset_converters/eco/metadata/building4.yaml
@@ -78,3 +78,7 @@ appliances:
   instance: 1
   #coverage: 97.08
   meters: [9] #Plug number
+  
+time_frame:
+  start: 2012-06-27
+  end: 2013-01-31

--- a/nilmtk/dataset_converters/eco/metadata/building5.yaml
+++ b/nilmtk/dataset_converters/eco/metadata/building5.yaml
@@ -78,3 +78,7 @@ appliances:
   instance: 1
   #coverage: 76.64
   meters: [9] #Plug number
+  
+time_frame:
+  start: 2012-06-27
+  end: 2013-01-31

--- a/nilmtk/dataset_converters/eco/metadata/building6.yaml
+++ b/nilmtk/dataset_converters/eco/metadata/building6.yaml
@@ -78,3 +78,7 @@ appliances:
   instance: 1
   #coverage: 82.54
   meters: [9] #Plug number
+  
+time_frame:
+  start: 2012-06-27
+  end: 2013-01-31

--- a/nilmtk/dataset_converters/eco/metadata/dataset.yaml
+++ b/nilmtk/dataset_converters/eco/metadata/dataset.yaml
@@ -17,5 +17,6 @@ timezone: CET
 geo_location:
   country: CH  # standard two-letter country code defined by ISO 3166-1 alpha-2
   latitude: 46.757
-  longitude: 7.61333related_documents:
+  longitude: 7.61333
+related_documents:
 - http://www.vs.inf.ethz.ch/publ/papers/beckel-2014-nilm.pdf

--- a/nilmtk/dataset_converters/eco/metadata/meter_devices.yaml
+++ b/nilmtk/dataset_converters/eco/metadata/meter_devices.yaml
@@ -1,76 +1,65 @@
 smart_meter:
   model:  Smart Meter
+  model_url: http://www.landisgyr.com/webfoo/wp-content/uploads/2012/12/Landis+Gyr-E750-Brochure-English.pdf
   description: >
     1 Hz aggregate consumption data. Each measurement contains data 
     on current, voltage, and phase shift for each of the three phases 
     in the household.
   sample_period: 1
-  max_sample_period: 1
+  max_sample_period: 10
   measurements:
   - physical_quantity: power #powerallphases
-    type: apparent
+    type: active
     upper_limit: 100000
-    lower_limit: 0
+    lower_limit: -1
   - physical_quantity: power #powerl1
-    type: apparent
+    type: active
     upper_limit: 100000
-    lower_limit: 0
+    lower_limit: -1
   - physical_quantity: power #powerl2
-    type: apparent
+    type: active
     upper_limit: 100000
-    lower_limit: 0
+    lower_limit: -1
   - physical_quantity: power #powerl3
-    type: apparent
+    type: active
     upper_limit: 100000
-    lower_limit: 0
+    lower_limit: -1
   - physical_quantity: current #currentneutral
-    type: apparent
     upper_limit: 20
-    lower_limit: 0
+    lower_limit: -1
   - physical_quantity: current #currentl1
-    type: apparent
     upper_limit: 20
-    lower_limit: 0
+    lower_limit: -1
   - physical_quantity: current #currentl2
-    type: apparent
     upper_limit: 20
-    lower_limit: 0
+    lower_limit: -1
   - physical_quantity: current #currentl3
-    type: apparent
     upper_limit: 20
-    lower_limit: 0
+    lower_limit: -1
   - physical_quantity: voltage #voltagel1
-    type: apparent
     upper_limit: 400
-    lower_limit: 100
+    lower_limit: -1
   - physical_quantity: voltage #voltagel2
-    type: apparent
     upper_limit: 400
-    lower_limit: 100
+    lower_limit: -1
   - physical_quantity: voltage #voltagel3
-    type: apparent
     upper_limit: 400
-    lower_limit: 100
-  - physical_quantity: phase angle #phaseanglevoltagel2l1
-    type: apparent
-    upper_limit: 400
-    lower_limit: 100
-  - physical_quantity: phase angle #phaseanglevoltagel3l1
-    type: apparent
-    upper_limit: 90
-    lower_limit: -90
-  - physical_quantity: phase angle #phaseanglecurrentvoltagel1
-    type: apparent
-    upper_limit: 90
-    lower_limit: -90
-  - physical_quantity: phase angle #phaseanglecurrentvoltagel2
-    type: apparent
-    upper_limit: 90
-    lower_limit: -90
-  - physical_quantity: phase angle #phaseanglecurrentvoltagel3
-    type: apparent
-    upper_limit: 90
-    lower_limit: -90
+    lower_limit: -1
+  - physical_quantity: phase_angle #phaseanglevoltagel2l1
+    upper_limit: 360
+    lower_limit: -1
+  - physical_quantity: phase_angle #phaseanglevoltagel3l1
+    upper_limit: 360
+    lower_limit: -1
+  - physical_quantity: phase_angle #phaseanglecurrentvoltagel1
+    upper_limit: 360
+    lower_limit: -1
+  - physical_quantity: phase_angle #phaseanglecurrentvoltagel2
+    upper_limit: 360
+    lower_limit: -1
+  - physical_quantity: phase_angle #phaseanglecurrentvoltagel3
+    upper_limit: 360
+    lower_limit: -1
   wireless: false
 
 plug:
@@ -78,10 +67,12 @@ plug:
   description: >
     1 Hz plug-level data measured from selected appliances.
   sample_period: 1
-  max_sample_period: 1
+  max_sample_period: 10
   measurements:
   - physical_quantity: power
-    type: active #Check active vs reactive vs apparant
-    upper_limit: 100000
-    lower_limit: 0
-  wireless: false
+    type: active
+    upper_limit: 10000
+    lower_limit: -1
+  wireless: true
+  wireless_configuration:
+    protocol: ZigBee


### PR DESCRIPTION
- Bugfix in ECO data set converter and metadata change
- In ECO data set converter: ignores files that start with '.', which often automatically happens in Mac OS (.DSStore)

Summary of the changes:

1) max_sample_period set to 10
[ what exactly does the max_sample_period do? I observed in other data sets that it is always higher than the actual sampling frequency ]

2) "apparent" set to "active" for both smart meter and plugs

3) added some metadata, also modified building two: split tablet computer charger [2] and laptops [10] - those are two different devices

4) removed "type" for non-power measurements

5) changed minimum value to -1
[ In the ECO data set, "-1" readings exist, but they denote missing measurements. This is handled differently in nilmtk, I will start a discussion in another thread ]

6) Finally, the reason why the converter was not working:
ipdb> key
/building1/elec/meter2
ipdb> key in store
False
ipdb> '/building1/elec/meter2' in store
True
ipdb> 

--> changed "key" to "str(key"

7) If a day only contains integers (e.g., only 0-measurements), it broke because pandas was not able to mix int and float tables

fix:
df = pd.read_csv(join(dir_loc,csv_name), names=[i for i in range(1,column_num+1)], dtype=np.float64)
