### PR TITLE
Specify num states

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ install:
   # Have to use pip for nose-cov because its entry points are not supported by conda yet
   - sudo rm -rf /dev/shm
   - sudo ln -s /run/shm /dev/shm
-  - sudo apt-get build-dep python-psycopg2
+  #- sudo apt-get build-dep python-psycopg2
   - pip install psycopg2
   - pip install git+https://github.com/hmmlearn/hmmlearn.git
   - pip install nose

--- a/nilmtk/disaggregate/combinatorial_optimisation.py
+++ b/nilmtk/disaggregate/combinatorial_optimisation.py
@@ -29,7 +29,7 @@ class CombinatorialOptimisation(object):
     def __init__(self):
         self.model = []
 
-    def train(self, metergroup, **load_kwargs):
+    def train(self, metergroup, num_states_dict = {}, **load_kwargs):
         """Train using 1D CO. Places the learnt model in the `model` attribute.
 
         Parameters
@@ -55,7 +55,12 @@ class CombinatorialOptimisation(object):
         for i, meter in enumerate(metergroup.submeters().meters):
             print("Training model for submeter '{}'".format(meter))
             for chunk in meter.power_series(**load_kwargs):
-                states = cluster(chunk, max_num_clusters)
+                num_total_states = num_states_dict.get(meter)
+                if num_total_states is not None:
+                    num_on_states = num_total_states-1
+                else:
+                    num_on_states = None
+                states = cluster(chunk, max_num_clusters, num_on_states)
                 self.model.append({
                     'states': states,
                     'training_metadata': meter})

--- a/nilmtk/disaggregate/combinatorial_optimisation.py
+++ b/nilmtk/disaggregate/combinatorial_optimisation.py
@@ -1,10 +1,13 @@
 from __future__ import print_function, division
+from datetime import datetime
+
 import pandas as pd
 import numpy as np
-from datetime import datetime
+
 from ..utils import find_nearest
 from ..feature_detectors import cluster
-from ..timeframe import merge_timeframes, list_of_timeframe_dicts, TimeFrame
+from ..timeframe import merge_timeframes, TimeFrame
+
 
 # Fix the seed for repeatability of experiments
 SEED = 42
@@ -12,7 +15,6 @@ np.random.seed(SEED)
 
 
 class CombinatorialOptimisation(object):
-
     """1 dimensional combinatorial optimisation NILM algorithm.
 
     Attributes
@@ -29,7 +31,7 @@ class CombinatorialOptimisation(object):
     def __init__(self):
         self.model = []
 
-    def train(self, metergroup, num_states_dict = {}, **load_kwargs):
+    def train(self, metergroup, num_states_dict={}, **load_kwargs):
         """Train using 1D CO. Places the learnt model in the `model` attribute.
 
         Parameters
@@ -57,7 +59,7 @@ class CombinatorialOptimisation(object):
             for chunk in meter.power_series(**load_kwargs):
                 num_total_states = num_states_dict.get(meter)
                 if num_total_states is not None:
-                    num_on_states = num_total_states-1
+                    num_on_states = num_total_states - 1
                 else:
                     num_on_states = None
                 states = cluster(chunk, max_num_clusters, num_on_states)
@@ -97,6 +99,7 @@ class CombinatorialOptimisation(object):
 
         # sklearn produces lots of DepreciationWarnings with PyTables
         import warnings
+
         warnings.filterwarnings("ignore", category=DeprecationWarning)
 
         # Extract optional parameters from load_kwargs
@@ -266,24 +269,24 @@ class CombinatorialOptimisation(object):
 
         output_datastore.save_metadata(building_path, building_metadata)
 
-    # TODO: fix export and import!
-    # https://github.com/nilmtk/nilmtk/issues/193
-    #
-    # def export_model(self, filename):
-    #     model_copy = {}
-    #     for appliance, appliance_states in self.model.iteritems():
-    #         model_copy[
-    #             "{}_{}".format(appliance.name, appliance.instance)] = appliance_states
-    #     j = json.dumps(model_copy)
-    #     with open(filename, 'w+') as f:
-    #         f.write(j)
+        # TODO: fix export and import!
+        # https://github.com/nilmtk/nilmtk/issues/193
+        #
+        # def export_model(self, filename):
+        #     model_copy = {}
+        #     for appliance, appliance_states in self.model.iteritems():
+        #         model_copy[
+        #             "{}_{}".format(appliance.name, appliance.instance)] = appliance_states
+        #     j = json.dumps(model_copy)
+        #     with open(filename, 'w+') as f:
+        #         f.write(j)
 
-    # def import_model(self, filename):
-    #     with open(filename, 'r') as f:
-    #         temp = json.loads(f.read())
-    #     for appliance, centroids in temp.iteritems():
-    #         appliance_name = appliance.split("_")[0].encode("ascii")
-    #         appliance_instance = int(appliance.split("_")[1])
-    #         appliance_name_instance = ApplianceID(
-    #             appliance_name, appliance_instance)
-    #         self.model[appliance_name_instance] = centroids
+        # def import_model(self, filename):
+        #     with open(filename, 'r') as f:
+        #         temp = json.loads(f.read())
+        #     for appliance, centroids in temp.iteritems():
+        #         appliance_name = appliance.split("_")[0].encode("ascii")
+        #         appliance_instance = int(appliance.split("_")[1])
+        #         appliance_name_instance = ApplianceID(
+        #             appliance_name, appliance_instance)
+        #         self.model[appliance_name_instance] = centroids

--- a/notebooks/experimental/test_num_states_co.ipynb
+++ b/notebooks/experimental/test_num_states_co.ipynb
@@ -1,0 +1,314 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "from nilmtk import DataSet, MeterGroup\n",
+    "import warnings\n",
+    "warnings.filterwarnings(\"ignore\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "ds = DataSet(\"/Users/nipunbatra/Downloads/wikienergy-2.h5\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "from nilmtk.disaggregate import CombinatorialOptimisation"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "co = CombinatorialOptimisation()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "building_num = 11"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "elec = ds.buildings[building_num].elec"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "MeterGroup(meters=\n",
+       "  ElecMeter(instance=1, building=11, dataset='WikiEnergy', site_meter, appliances=[])\n",
+       "  ElecMeter(instance=2, building=11, dataset='WikiEnergy', appliances=[Appliance(type='air conditioner', instance=1)])\n",
+       "  ElecMeter(instance=3, building=11, dataset='WikiEnergy', appliances=[Appliance(type='sockets', instance=1)])\n",
+       "  ElecMeter(instance=4, building=11, dataset='WikiEnergy', appliances=[Appliance(type='sockets', instance=2)])\n",
+       "  ElecMeter(instance=5, building=11, dataset='WikiEnergy', appliances=[Appliance(type='dish washer', instance=1)])\n",
+       "  ElecMeter(instance=6, building=11, dataset='WikiEnergy', appliances=[Appliance(type='spin dryer', instance=1)])\n",
+       "  ElecMeter(instance=7, building=11, dataset='WikiEnergy', appliances=[Appliance(type='electric furnace', instance=1)])\n",
+       "  ElecMeter(instance=8, building=11, dataset='WikiEnergy', appliances=[Appliance(type='sockets', instance=3)])\n",
+       "  ElecMeter(instance=9, building=11, dataset='WikiEnergy', appliances=[Appliance(type='sockets', instance=4)])\n",
+       "  ElecMeter(instance=10, building=11, dataset='WikiEnergy', appliances=[Appliance(type='fridge', instance=1)])\n",
+       "  ElecMeter(instance=11, building=11, dataset='WikiEnergy', appliances=[Appliance(type='electric water heating appliance', instance=1)])\n",
+       ")"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "elec"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "fridge_elecmeter = elec['fridge']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "ElecMeter(instance=10, building=11, dataset='WikiEnergy', appliances=[Appliance(type='fridge', instance=1)])"
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "fridge_elecmeter"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "fridge_mg = MeterGroup([fridge_elecmeter])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Training model for submeter 'ElecMeter(instance=10, building=11, dataset='WikiEnergy', appliances=[Appliance(type='fridge', instance=1)])'\n",
+      "Done training!\n"
+     ]
+    }
+   ],
+   "source": [
+    "co.train(fridge_mg)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[{'states': array([  0, 138, 415], dtype=int32),\n",
+       "  'training_metadata': ElecMeter(instance=10, building=11, dataset='WikiEnergy', appliances=[Appliance(type='fridge', instance=1)])}]"
+      ]
+     },
+     "execution_count": 14,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "co.model"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "So, fridge is learnt as a 3 state appliance. What if we wanted to specify it to use 2 states? The latest version of nilmtk allows us to specify the number of states for an appliance."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "num_states_dict = {fridge_elecmeter:2}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Training model for submeter 'ElecMeter(instance=2, building=11, dataset='WikiEnergy', appliances=[Appliance(type='air conditioner', instance=1)])'\n",
+      "Training model for submeter 'ElecMeter(instance=3, building=11, dataset='WikiEnergy', appliances=[Appliance(type='sockets', instance=1)])'\n",
+      "Training model for submeter 'ElecMeter(instance=4, building=11, dataset='WikiEnergy', appliances=[Appliance(type='sockets', instance=2)])'\n",
+      "Training model for submeter 'ElecMeter(instance=5, building=11, dataset='WikiEnergy', appliances=[Appliance(type='dish washer', instance=1)])'\n",
+      "Training model for submeter 'ElecMeter(instance=6, building=11, dataset='WikiEnergy', appliances=[Appliance(type='spin dryer', instance=1)])'\n",
+      "Training model for submeter 'ElecMeter(instance=7, building=11, dataset='WikiEnergy', appliances=[Appliance(type='electric furnace', instance=1)])'\n",
+      "Training model for submeter 'ElecMeter(instance=8, building=11, dataset='WikiEnergy', appliances=[Appliance(type='sockets', instance=3)])'\n",
+      "Training model for submeter 'ElecMeter(instance=9, building=11, dataset='WikiEnergy', appliances=[Appliance(type='sockets', instance=4)])'\n",
+      "Training model for submeter 'ElecMeter(instance=10, building=11, dataset='WikiEnergy', appliances=[Appliance(type='fridge', instance=1)])'\n",
+      "Training model for submeter 'ElecMeter(instance=11, building=11, dataset='WikiEnergy', appliances=[Appliance(type='electric water heating appliance', instance=1)])'\n",
+      "Done training!\n"
+     ]
+    }
+   ],
+   "source": [
+    "co = CombinatorialOptimisation()\n",
+    "co.train(fri, num_states_dict=num_states_dict)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[{'states': array([   0, 1023, 2995], dtype=int32),\n",
+       "  'training_metadata': ElecMeter(instance=2, building=11, dataset='WikiEnergy', appliances=[Appliance(type='air conditioner', instance=1)])},\n",
+       " {'states': array([ 0, 16, 73], dtype=int32),\n",
+       "  'training_metadata': ElecMeter(instance=3, building=11, dataset='WikiEnergy', appliances=[Appliance(type='sockets', instance=1)])},\n",
+       " {'states': array([ 0, 24, 94], dtype=int32),\n",
+       "  'training_metadata': ElecMeter(instance=4, building=11, dataset='WikiEnergy', appliances=[Appliance(type='sockets', instance=2)])},\n",
+       " {'states': array([   0,  196, 1037], dtype=int32),\n",
+       "  'training_metadata': ElecMeter(instance=5, building=11, dataset='WikiEnergy', appliances=[Appliance(type='dish washer', instance=1)])},\n",
+       " {'states': array([   0, 1177, 4713], dtype=int32),\n",
+       "  'training_metadata': ElecMeter(instance=6, building=11, dataset='WikiEnergy', appliances=[Appliance(type='spin dryer', instance=1)])},\n",
+       " {'states': array([  0,  14, 455], dtype=int32),\n",
+       "  'training_metadata': ElecMeter(instance=7, building=11, dataset='WikiEnergy', appliances=[Appliance(type='electric furnace', instance=1)])},\n",
+       " {'states': array([  0,  37, 927], dtype=int32),\n",
+       "  'training_metadata': ElecMeter(instance=8, building=11, dataset='WikiEnergy', appliances=[Appliance(type='sockets', instance=3)])},\n",
+       " {'states': array([  0,  57, 178], dtype=int32),\n",
+       "  'training_metadata': ElecMeter(instance=9, building=11, dataset='WikiEnergy', appliances=[Appliance(type='sockets', instance=4)])},\n",
+       " {'states': array([  0, 145], dtype=int32),\n",
+       "  'training_metadata': ElecMeter(instance=10, building=11, dataset='WikiEnergy', appliances=[Appliance(type='fridge', instance=1)])},\n",
+       " {'states': array([  0,  30, 131], dtype=int32),\n",
+       "  'training_metadata': ElecMeter(instance=11, building=11, dataset='WikiEnergy', appliances=[Appliance(type='electric water heating appliance', instance=1)])}]"
+      ]
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "co.model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "Now, fridge is a 2 state appliance."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 2",
+   "language": "python",
+   "name": "python2"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/notebooks/experimental/test_num_states_co.ipynb
+++ b/notebooks/experimental/test_num_states_co.ipynb
@@ -209,7 +209,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 16,
    "metadata": {
     "collapsed": false
    },
@@ -218,28 +218,19 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Training model for submeter 'ElecMeter(instance=2, building=11, dataset='WikiEnergy', appliances=[Appliance(type='air conditioner', instance=1)])'\n",
-      "Training model for submeter 'ElecMeter(instance=3, building=11, dataset='WikiEnergy', appliances=[Appliance(type='sockets', instance=1)])'\n",
-      "Training model for submeter 'ElecMeter(instance=4, building=11, dataset='WikiEnergy', appliances=[Appliance(type='sockets', instance=2)])'\n",
-      "Training model for submeter 'ElecMeter(instance=5, building=11, dataset='WikiEnergy', appliances=[Appliance(type='dish washer', instance=1)])'\n",
-      "Training model for submeter 'ElecMeter(instance=6, building=11, dataset='WikiEnergy', appliances=[Appliance(type='spin dryer', instance=1)])'\n",
-      "Training model for submeter 'ElecMeter(instance=7, building=11, dataset='WikiEnergy', appliances=[Appliance(type='electric furnace', instance=1)])'\n",
-      "Training model for submeter 'ElecMeter(instance=8, building=11, dataset='WikiEnergy', appliances=[Appliance(type='sockets', instance=3)])'\n",
-      "Training model for submeter 'ElecMeter(instance=9, building=11, dataset='WikiEnergy', appliances=[Appliance(type='sockets', instance=4)])'\n",
       "Training model for submeter 'ElecMeter(instance=10, building=11, dataset='WikiEnergy', appliances=[Appliance(type='fridge', instance=1)])'\n",
-      "Training model for submeter 'ElecMeter(instance=11, building=11, dataset='WikiEnergy', appliances=[Appliance(type='electric water heating appliance', instance=1)])'\n",
       "Done training!\n"
      ]
     }
    ],
    "source": [
     "co = CombinatorialOptimisation()\n",
-    "co.train(fri, num_states_dict=num_states_dict)"
+    "co.train(fridge_mg, num_states_dict=num_states_dict)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 17,
    "metadata": {
     "collapsed": false
    },
@@ -247,29 +238,11 @@
     {
      "data": {
       "text/plain": [
-       "[{'states': array([   0, 1023, 2995], dtype=int32),\n",
-       "  'training_metadata': ElecMeter(instance=2, building=11, dataset='WikiEnergy', appliances=[Appliance(type='air conditioner', instance=1)])},\n",
-       " {'states': array([ 0, 16, 73], dtype=int32),\n",
-       "  'training_metadata': ElecMeter(instance=3, building=11, dataset='WikiEnergy', appliances=[Appliance(type='sockets', instance=1)])},\n",
-       " {'states': array([ 0, 24, 94], dtype=int32),\n",
-       "  'training_metadata': ElecMeter(instance=4, building=11, dataset='WikiEnergy', appliances=[Appliance(type='sockets', instance=2)])},\n",
-       " {'states': array([   0,  196, 1037], dtype=int32),\n",
-       "  'training_metadata': ElecMeter(instance=5, building=11, dataset='WikiEnergy', appliances=[Appliance(type='dish washer', instance=1)])},\n",
-       " {'states': array([   0, 1177, 4713], dtype=int32),\n",
-       "  'training_metadata': ElecMeter(instance=6, building=11, dataset='WikiEnergy', appliances=[Appliance(type='spin dryer', instance=1)])},\n",
-       " {'states': array([  0,  14, 455], dtype=int32),\n",
-       "  'training_metadata': ElecMeter(instance=7, building=11, dataset='WikiEnergy', appliances=[Appliance(type='electric furnace', instance=1)])},\n",
-       " {'states': array([  0,  37, 927], dtype=int32),\n",
-       "  'training_metadata': ElecMeter(instance=8, building=11, dataset='WikiEnergy', appliances=[Appliance(type='sockets', instance=3)])},\n",
-       " {'states': array([  0,  57, 178], dtype=int32),\n",
-       "  'training_metadata': ElecMeter(instance=9, building=11, dataset='WikiEnergy', appliances=[Appliance(type='sockets', instance=4)])},\n",
-       " {'states': array([  0, 145], dtype=int32),\n",
-       "  'training_metadata': ElecMeter(instance=10, building=11, dataset='WikiEnergy', appliances=[Appliance(type='fridge', instance=1)])},\n",
-       " {'states': array([  0,  30, 131], dtype=int32),\n",
-       "  'training_metadata': ElecMeter(instance=11, building=11, dataset='WikiEnergy', appliances=[Appliance(type='electric water heating appliance', instance=1)])}]"
+       "[{'states': array([  0, 144], dtype=int32),\n",
+       "  'training_metadata': ElecMeter(instance=10, building=11, dataset='WikiEnergy', appliances=[Appliance(type='fridge', instance=1)])}]"
       ]
      },
-     "execution_count": 13,
+     "execution_count": 17,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -279,15 +252,20 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now, fridge is learnt as a 2 state appliance."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
     "collapsed": true
    },
    "outputs": [],
-   "source": [
-    "Now, fridge is a 2 state appliance."
-   ]
+   "source": []
   }
  ],
  "metadata": {

--- a/notebooks/experimental/test_num_states_co_fhmm.ipynb
+++ b/notebooks/experimental/test_num_states_co_fhmm.ipynb
@@ -2,11 +2,21 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 1,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Vendor:  Continuum Analytics, Inc.\n",
+      "Package: mkl\n",
+      "Message: trial mode expires in 29 days\n"
+     ]
+    }
+   ],
    "source": [
     "from nilmtk import DataSet, MeterGroup\n",
     "import warnings\n",
@@ -69,8 +79,26 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Reducing time window"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 7,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "ds.set_window(start='2014-04-01 00:00:00', end='2014-05-01 00:00:00')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
    "metadata": {
     "collapsed": false
    },
@@ -93,7 +121,7 @@
        ")"
       ]
      },
-     "execution_count": 7,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -137,7 +165,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 11,
    "metadata": {
     "collapsed": false
    },
@@ -148,7 +176,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 12,
    "metadata": {
     "collapsed": false
    },
@@ -168,7 +196,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 13,
    "metadata": {
     "collapsed": false
    },
@@ -176,11 +204,11 @@
     {
      "data": {
       "text/plain": [
-       "[{'states': array([  0, 138, 415], dtype=int32),\n",
+       "[{'states': array([  0, 139, 431], dtype=int32),\n",
        "  'training_metadata': ElecMeter(instance=10, building=11, dataset='WikiEnergy', appliances=[Appliance(type='fridge', instance=1)])}]"
       ]
      },
-     "execution_count": 14,
+     "execution_count": 13,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -198,7 +226,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 14,
    "metadata": {
     "collapsed": true
    },
@@ -209,7 +237,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 15,
    "metadata": {
     "collapsed": false
    },
@@ -230,7 +258,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 16,
    "metadata": {
     "collapsed": false
    },
@@ -238,11 +266,11 @@
     {
      "data": {
       "text/plain": [
-       "[{'states': array([  0, 144], dtype=int32),\n",
+       "[{'states': array([  0, 143], dtype=int32),\n",
        "  'training_metadata': ElecMeter(instance=10, building=11, dataset='WikiEnergy', appliances=[Appliance(type='fridge', instance=1)])}]"
       ]
      },
-     "execution_count": 17,
+     "execution_count": 16,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -256,6 +284,130 @@
    "metadata": {},
    "source": [
     "Now, fridge is learnt as a 2 state appliance."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let us try the same thing with FHMM now"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "from nilmtk.disaggregate import FHMM"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "f = FHMM()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Learnt states:  3\n",
+      "Training model for submeter 'ElecMeter(instance=10, building=11, dataset='WikiEnergy', appliances=[Appliance(type='fridge', instance=1)])'\n"
+     ]
+    }
+   ],
+   "source": [
+    "f.train(fridge_mg)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([[   3.02034344],\n",
+       "       [ 146.2202185 ],\n",
+       "       [ 176.49027576]])"
+      ]
+     },
+     "execution_count": 20,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "f.model.means_"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "User specified  2\n",
+      "Training model for submeter 'ElecMeter(instance=10, building=11, dataset='WikiEnergy', appliances=[Appliance(type='fridge', instance=1)])'\n"
+     ]
+    }
+   ],
+   "source": [
+    "f = FHMM()\n",
+    "f.train(fridge_mg, num_states_dict)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([[   0.        ],\n",
+       "       [ 144.87951888]])"
+      ]
+     },
+     "execution_count": 22,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "f.model.means_"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "So, now we have a 2 state learnt model for the Fridge."
    ]
   },
   {


### PR DESCRIPTION
This branch adds a bunch of new functionality:

CO
-----

1. We can give the number of states we wish to train an elecmeter on

FHMM
----------

1. We can give the number of states we wish to train an elecmeter on
2. Earlier, we were using a hardcoded value of 2 as the number of states on which the FHMM would be learnt. Now, it borrows the code using in CO for finding the optimal number of states.