### PR TITLE
Update data.ipynb

### DIFF
--- a/docs/manual/user_guide/data.ipynb
+++ b/docs/manual/user_guide/data.ipynb
@@ -63,7 +63,7 @@
    ],
    "source": [
     "from nilmtk.dataset_converters import convert_redd\n",
-    "convert_redd('/data/REDD/low_freq', '/data/REDD/redd.h5')"
+    "convert_redd('data/REDD/low_freq', 'data/REDD/redd.h5')"
    ]
   },
   {


### PR DESCRIPTION
As suggested by abhisheknalin in the link https://github.com/nilmtk/nilmtk/issues/185, the following code:
```
convert_redd('/data/REDD/low_freq', '/data/REDD/redd.h5')
```
was changed to
```
convert_redd('data/REDD/low_freq', 'data/REDD/redd.h5')
```

That made the conversion to work properly on my laptop (OSX El Capitan). 

Alternatively, a comment could be added to warn the user to make this change if necessary. A suggestion of comment:
```
# Note: some users reported to change the code to convert_redd('data/REDD/low_freq', 'data/REDD/redd.h5') in order to make the conversion work properly. 
```