### PR TITLE
Update of refit converter for clean data

### DIFF
--- a/docs/pre_process_sphinx_rst.py
+++ b/docs/pre_process_sphinx_rst.py
@@ -1,0 +1,428 @@
+#!/usr/bin/env python2
+# -*- coding: utf-8 -*-
+"""
+Created on Wed Dec  6 15:06:59 2017
+
+@author: martinneighbours
+
+*** Objective ***
+
+The purpose of this module is to create more readable api docs by
+- including autosummaries at the top of the module before the detail of the module
+- removing the modules section from intermediate levels with no modules
+
+This is not appropriate for all modules so the min_members_to_document parameter can be
+used to limit the modules that are modified.
+
+Also not all modules will document with autosummary, so to avoid creating an error, an
+exclude_list has been included which will default to modules
+
+The core content of this module has been borrowed from sphinx-autosummary generate.py
+
+Example
+-------
+>>> main(['modules','nilmtk.tests.test_datastore_converter'],5,'nilmtk')
+
+"""
+
+from __future__ import print_function
+
+import os
+import sys
+import shlex, subprocess
+import re
+
+from jinja2 import FileSystemLoader, TemplateNotFound
+from jinja2.sandbox import SandboxedEnvironment
+from sphinx.util.rst import escape as rst_escape
+
+from sphinx.ext.autosummary import import_by_name, get_documenter
+from sphinx.util.inspect import safe_getattr
+# Add documenters to AutoDirective registry
+from sphinx.ext.autodoc import add_documenter, \
+    ModuleDocumenter, ClassDocumenter, ExceptionDocumenter, DataDocumenter, \
+    FunctionDocumenter, MethodDocumenter, AttributeDocumenter, \
+    InstanceAttributeDocumenter
+
+
+
+add_documenter(ModuleDocumenter)
+add_documenter(ClassDocumenter)
+add_documenter(ExceptionDocumenter)
+add_documenter(DataDocumenter)
+add_documenter(FunctionDocumenter)
+add_documenter(MethodDocumenter)
+add_documenter(AttributeDocumenter)
+add_documenter(InstanceAttributeDocumenter)
+
+# Utility functions -----------------------------------------------------------
+
+def get_class_that_defined_method(method):
+    '''Return the fullname of the class that the method was created in
+    
+    Parameters
+    ----------
+    method: obj, method object
+    
+    Returns
+    -------
+    str
+        The __name__ of the class that the method originated in 
+    '''
+    method_name = method.__name__
+
+    try: 
+        if method.__self__:    
+            classes = [method.__self__.__class__]
+        else:
+            #unbound method
+            classes = [method.im_class]
+        while classes:
+            c = classes.pop()
+            if method_name in c.__dict__:
+                return c.__name__
+            else:
+                classes = list(c.__bases__) + classes
+    except:
+        return 'Unable to determine class type'
+    return None
+
+# borrowed from sphinx-autosummary - amended quite a bit
+def get_members(obj, typ, include_public=[], imported=False):
+# type: (Any, unicode, List[unicode], bool) -> Tuple[List[unicode], List[unicode]]  # NOQA
+   '''Document different members from a module
+   
+   Restricted to members from the same application as the object
+   
+   Parameters
+   ----------
+   obj: obj
+       A module that can be imported
+   typ: str
+       {Function, class, exception, method, attribute}
+   include_public: list, optional
+       allows for sub-selection of public methods (default [])
+   imported: bool, optional
+       Whether to include imported members (default = False)
+   
+   Returns
+   -------
+   public: list
+       List of public members for the chosen typ
+   items: list
+       List of all members for the chosen typ
+   inherited_method_flag: bool
+       True if any of the methods in the class are inherited
+
+   Notes
+   -----
+   The original code has been borrowed from sphinx-autosummary generate.py and 
+   amended quite a bit to try and accomodate methods and attributes (there was 
+   a bug in the original code) which excluded these.
+   
+   Also amended to include a flag used to show if the class includes any 
+   inherited methods from the same application.
+   '''
+   
+   try:
+        app_package = obj.__module__.split('.')[0]
+   except:
+        app_package = obj.__name__.split('.')[0]
+   inherited_method_flag = False
+   items = []  # type: List[unicode]
+   for name in dir(obj):
+        try:
+            value = safe_getattr(obj, name)
+            if typ != 'attribute' and (getattr(value, '__module__', None) 
+                is None or getattr(value, '__module__', None).split('.')[0] 
+                != app_package): #only consider members from same app
+                continue
+        except AttributeError:
+            continue
+        documenter = get_documenter(value, obj)
+        if documenter.objtype == typ:
+            if typ == 'method':
+                orig_class = get_class_that_defined_method(value)
+                if imported or orig_class == obj.__name__:
+                    items.append(name)
+                else: 
+                    if orig_class is not None and \
+                        orig_class != 'Unable to determine class type':
+                        inherited_method_flag = True
+            if typ == 'attribute':
+                items.append(name)
+            elif imported or getattr(value, '__module__', None) == obj.__name__:
+                # skip imported members if expected
+                items.append(name)
+   public = [x for x in items
+              if x in include_public or not x.startswith('_')]
+   return public, items, inherited_method_flag
+
+
+def process(cmd):
+    '''Utility function to execute terminal commands and return the results
+    
+    Parameters
+    ----------    
+    cmd: str
+        command to execture
+    
+    Returns
+    -------
+    out: str
+        Returned stdout output
+    err: str
+        Returned stderr output
+    errorcode: int
+        Returned errorcode 0 = o.k.
+    
+    Example
+    -------
+    
+    >>> cmd = "sphinx-apidoc -f -e -n -o source ../nilmtk"
+    >>> stream, err, errcode = process(cmd)
+    '''
+    process = subprocess.Popen(cmd, shell=True,
+                           stdout=subprocess.PIPE, 
+                           stderr=subprocess.PIPE)
+
+    # wait for the process to terminate
+    out, err = process.communicate()
+    errcode = process.returncode
+    return out, err, errcode
+
+# iterate through each module etc and populate the members
+
+def create_module_details(app_modules,exclude_list=['modules']):
+    '''Scans through all modules and populates the member details
+    
+    Parameters
+    ----------
+    app_modules: list
+        List of all modules in the app
+    exclude_list: list
+        List of modules which are incompatible with autosummary or summary
+        tables are not required for. (defaul ['modules'])
+    
+    Returns
+    -------
+    List
+        Lists of all functions, classes, exceptions and for each class sub
+        lists of all the methods and attributes as well as a flag to show that
+        the class contains inherited members
+    '''
+    app_module_details = []
+    imported_members = False
+    for app_module in app_modules:
+        if app_module not in exclude_list:
+            app_module_detail = [app_module,{'function':[],'class':[],'exception':[],'method':{},'Inherited method flag':{}, 'attribute':{},'Total members':0}]
+            name, obj, parent, mod_name = import_by_name(app_module)
+            for member in ['function','class','exception']:
+                public, items, _ = get_members(obj, member , imported=imported_members)
+                app_module_detail[1][member] = public
+                app_module_detail[1]['Total members'] += len(public)
+                # iterate through the classes
+                for mod_class in app_module_detail[1]['class']:
+                    for member in ['method','attribute']:
+                        name, obj, parent, mod_name = import_by_name(app_module+'.'+mod_class)
+                        public, items, inherited_method_flag = get_members(obj, member , imported=imported_members) 
+                        app_module_detail[1][member][mod_class] = public
+                        app_module_detail[1]['Total members'] += len(public)
+                        if member == 'method':
+                            app_module_detail[1]['Inherited method flag'][mod_class] = inherited_method_flag
+            app_module_details.append(app_module_detail)
+    return app_module_details
+
+def insert_lines(member_list,member_type,padding=''):
+    '''Utility function to deal with autosummaries in the rst file for different member types
+    
+    Uses a dictionary to map the source names to more user friendly display names.  This should
+    be converted to a template.
+    
+    Parameters
+    ----------
+    member_list: list
+        the members to be summarised
+    member_type: str
+        the type of member - function, class, exception, method, attribute
+    padding: str
+        used to ensure that the autosummary is in the same scope
+    
+    Returns
+    -------
+    str
+        text to insert into the rst file
+    '''
+    member_desc = {'function':'Functions',
+                   'class':'Classes',
+                   'exception':'Exceptions',
+                   'method':'Methods',
+                   'attribute':'Attributes'}
+    lines_to_insert = padding + '.. rubric:: ' + member_desc[member_type] + '\n' *2
+    lines_to_insert += padding + '.. autosummary::' + '\n' * 2
+    for member in member_list:
+        lines_to_insert += padding + '    ' + member + '\n'
+    lines_to_insert += '\n' * 2
+    return lines_to_insert
+
+def _underline(title, line='='):
+    if '\n' in title:
+        raise ValueError('Can only underline single lines')
+    return title + '\n' + line * len(title)
+
+def update_modules(app_module_details, min_members_to_document=5):
+    '''  Inserts module and class updates to the module.rst files
+    
+    Makes use of module_class.tplt which is stored in source/_templates
+    
+    Parameters
+    ----------
+    app_module_details: list
+        Contains all the functions, classes, exceptions and for each class a dictionary
+        list of all the methods and attributes with a flag to show inherited methods
+    min_members_to_document: int
+        No changes will be applied to modules with less than this number of members
+    '''
+    # modify the files by finding the relevant automodule directive
+    for app_module in app_module_details:
+        if app_module[1]['Total members'] >= min_members_to_document:
+
+            # setup template directory
+            template_dirs = ['source/_templates']
+            
+            template_loader = FileSystemLoader(template_dirs)
+            template_env = SandboxedEnvironment(loader=template_loader)
+ 
+            template_env.filters['underline'] = _underline
+                  
+            # replace the builtin html filters
+            template_env.filters['escape'] = rst_escape
+            template_env.filters['e'] = rst_escape
+            
+            template_name = 'module_class.tplt'
+            
+            ns = {}  # type: Dict[unicode, Any]
+            ns['functions'] = app_module[1]['function']
+            ns['classes'] = app_module[1]['class']
+            ns['exceptions'] = app_module[1]['exception']
+            
+            name = app_module[0]
+            parts = name.split('.')
+            mod_name, obj_name = '.'.join(parts[:-1]), parts[-1]
+            
+            ns['fullname'] = name
+            ns['module'] = mod_name
+            ns['objname'] = obj_name
+            ns['name'] = parts[-1]
+        
+            ns['objtype'] = 'module'
+            ns['underline'] = len(name) * '='
+            ns['methods'] = app_module[1]['method']
+            ns['attributes'] = app_module[1]['attribute']
+            ns['inherited_method_flags'] = app_module[1]['Inherited method flag']
+            
+            template = template_env.get_template(template_name)
+            rendered = template.render(**ns)
+
+            filename = 'source/' + app_module[0] + '.rst' 
+            print ('Modifying file :' + filename)
+            with open(filename,'w') as f:
+                f.write(rendered)
+                
+  
+def remove_empty_module_contents(app_module_details):
+    '''Removes the Module header from any rst files that don't have any modules
+    
+    Parameters
+    ----------
+    app_module_contents: list
+        List of modules and their contents
+    '''
+    # remove module contents from any members that don't have modules
+    # these will generally be sub packages and clutter the toc tree
+    for app_module_detail in app_module_details:
+        if app_module_detail[1]['Total members'] == 0:
+            # see if it has a module contents section (not all will)
+            filename = 'source/' + app_module_detail[0] + '.rst'
+            infile = open(filename,'r+').readlines()
+            if 'Module contents\n' in infile:
+                inx_line = infile.index('Module contents\n')
+                f = open(filename,'w')
+                f.write("".join(infile[:inx_line]))
+                f.close
+                print ('Removing module contents from :' + filename)
+
+             
+def main(exclude_list,min_members_to_document,app):
+
+    # return the initial list of files from sphinx-apidoc using a dummy run
+    cmd = "sphinx-apidoc -f -e -n -o source ../" + app
+    stream, err, errcode = process(cmd)
+    
+    if errcode == 0:
+        print ('Sphinx-apidoc dummy list created')
+    else:
+        print ('Failed to create dummy list')
+        return
+    
+    # pull out the files created
+    app_list = shlex.split(stream)
+    p = re.compile('(source/)(\S+).rst.')
+    # create a list of modules
+    app_modules = [x.group(2) for l in app_list for x in [p.match(l)] if x]
+
+    # populate the contents of all the modules
+    app_module_details = create_module_details(app_modules,exclude_list=exclude_list)
+
+    # now create the rst files for real
+    cmd = "sphinx-apidoc -f -e -o source ../" + app
+    stream, err, errcode = process(cmd)
+    if errcode == 0:
+        print ('Base rst files built succcesfully')
+    else:
+        print ('Could not create the base rst files')
+
+    # get user to agree to changes                 
+    print ('The following modules have >= %0.f members :' % min_members_to_document)
+    for app_module in app_module_details:
+        if app_module[1]['Total members'] >= min_members_to_document:
+            print (app_module[0])
+            
+    modify_files = raw_input('Proceed? y/n :')
+    if modify_files.upper() == 'Y':
+        update_modules(app_module_details,min_members_to_document)
+    else:
+        print ('No changes applied to modules')
+
+    remove_module_contents = raw_input('Remove empty sections from intermediate pages? y/n :')
+    if remove_module_contents.upper() == 'Y':
+        remove_empty_module_contents(app_module_details)
+    else:
+        print ('No changes applied to intermediate pages')
+
+if __name__ == '__main__':
+    # if run from the command line
+    import argparse
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "exclude_list",
+        nargs="*", 
+        type=str,
+        default=['module.rst'],  # default list if no arg value
+        help = 'List of rst files to exclude from processing'
+    )
+    parser.add_argument(
+            "min_members_to_document",
+            type=int,
+            default=5,
+            help = 'Modules with less than this number of members will not get a summary table'
+    )
+    parser.add_argument(
+            "app",
+            type=str,
+            default='',
+            help = 'Name of the application to process'
+    )
+    args = parser.parse_args()
+    main(args.exclude_list,args.min_members_to_document,args.app)
+    

--- a/docs/source/_static/copybutton.js
+++ b/docs/source/_static/copybutton.js
@@ -1,0 +1,65 @@
+// Copyright 2014 PSF. Licensed under the PYTHON SOFTWARE FOUNDATION LICENSE VERSION 2
+// File originates from the cpython source found in Doc/tools/sphinxext/static/copybutton.js
+
+$(document).ready(function() {
+                  /* Add a [>>>] button on the top-right corner of code samples to hide
+                   * the >>> and ... prompts and the output and thus make the code
+                   * copyable. */
+                  var div = $('.highlight-python .highlight,' +
+                              '.highlight-default .highlight,' +
+                              '.highlight-python3 .highlight')
+                  var pre = div.find('pre');
+                  
+                  // get the styles from the current theme
+                  pre.parent().parent().css('position', 'relative');
+                  var hide_text = 'Hide the prompts and output';
+                  var show_text = 'Show the prompts and output';
+                  var border_width = pre.css('border-top-width');
+                  var border_style = pre.css('border-top-style');
+                  var border_color = pre.css('border-top-color');
+                  var button_styles = {
+                  'cursor':'pointer', 'position': 'absolute', 'top': '0', 'right': '0',
+                  'border-color': border_color, 'border-style': border_style,
+                  'border-width': border_width, 'color': border_color, 'text-size': '75%',
+                  'font-family': 'monospace', 'padding-left': '0.2em', 'padding-right': '0.2em',
+                  'border-radius': '0 3px 0 0'
+                  }
+                  
+                  // create and add the button to all the code blocks that contain >>>
+                  div.each(function(index) {
+                           var jthis = $(this);
+                           if (jthis.find('.gp').length > 0) {
+                           var button = $('<span class="copybutton">&gt;&gt;&gt;</span>');
+                           button.css(button_styles)
+                           button.attr('title', hide_text);
+                           button.data('hidden', 'false');
+                           jthis.prepend(button);
+                           }
+                           // tracebacks (.gt) contain bare text elements that need to be
+                           // wrapped in a span to work with .nextUntil() (see later)
+                           jthis.find('pre:has(.gt)').contents().filter(function() {
+                                                                        return ((this.nodeType == 3) && (this.data.trim().length > 0));
+                                                                        }).wrap('<span>');
+                           });
+                  
+                  // define the behavior of the button when it's clicked
+                  $('.copybutton').click(function(e){
+                                         e.preventDefault();
+                                         var button = $(this);
+                                         if (button.data('hidden') === 'false') {
+                                         // hide the code output
+                                         button.parent().find('.go, .gp, .gt').hide();
+                                         button.next('pre').find('.gt').nextUntil('.gp, .go').css('visibility', 'hidden');
+                                         button.css('text-decoration', 'line-through');
+                                         button.attr('title', show_text);
+                                         button.data('hidden', 'true');
+                                         } else {
+                                         // show the code output
+                                         button.parent().find('.go, .gp, .gt').show();
+                                         button.next('pre').find('.gt').nextUntil('.gp, .go').css('visibility', 'visible');
+                                         button.css('text-decoration', 'none');
+                                         button.attr('title', hide_text);
+                                         button.data('hidden', 'false');
+                                         }
+                                         });
+                  });

--- a/docs/source/_templates/module_class.tplt
+++ b/docs/source/_templates/module_class.tplt
@@ -1,0 +1,76 @@
+{{ fullname | escape | underline}}
+
+.. topic:: Module summary
+
+    .. automodule:: {{ fullname }}
+       :no-members:
+       :no-undoc-members:
+       :no-show-inheritance: {% block functions %}{% if functions %}
+
+       .. rubric:: Functions
+
+       .. autosummary::
+{% for item in functions %}
+          {{ item }}{%- endfor %}{% endif %}{% endblock %}
+{% block classes %}
+    {% if classes %}
+       .. rubric:: Classes
+
+       .. autosummary::
+        {% for item in classes %}
+          {{ item }}
+        {%- endfor %}
+    {% endif %}
+{% endblock %}
+{% block exceptions %}
+    {% if exceptions %}
+       .. rubric:: Exceptions
+
+       .. autosummary::
+
+    {% for item in exceptions %}
+          {{ item }}
+        {%- endfor %}
+    {% endif %}
+{% endblock %}
+{% block classes_detail %}
+    {% if classes %}
+        {% for class in classes %}
+
+.. topic:: Class: {{class}}
+
+    .. autoclass:: {{class}}
+       :no-members:
+       :no-undoc-members:
+            {% if inherited_method_flags[class] %}
+       .. Note:: This class has inherited methods, see the base class(es) for additional methods
+            {% endif%}
+            {% if methods[class] != [] %}
+       .. rubric:: Methods
+
+       .. autosummary::
+                {% for method in methods[class] %}
+            {{method}}
+                {%- endfor %}
+            {% endif %}
+            {% if attributes[class] != [] %}
+       .. rubric:: Attributes
+
+       .. autosummary::
+                {% for attribute in attributes[class] %}
+            {{attribute}}
+                {%- endfor %}
+            {% endif %}
+        {%- endfor %}
+    {% endif %}
+{% endblock %}
+
+.. rubric:: Module detail
+
+.. automodule:: {{ fullname }}
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -19,7 +19,9 @@ import sphinx_bootstrap_theme
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
-#sys.path.insert(0, os.path.abspath('.'))
+sys.path.insert(0, os.path.abspath('../..'))
+
+print(sys.path)
 
 # -- General configuration ------------------------------------------------
 
@@ -31,26 +33,38 @@ import sphinx_bootstrap_theme
 # ones.
 
 extensions = [
+#    'autodocsumm', # in place of autodoc
     'sphinx.ext.autodoc',
+    'sphinx.ext.doctest',
     'sphinx.ext.mathjax',
-    'sphinx.ext.ifconfig',
-    'sphinx.ext.viewcode',
+#    'sphinx.ext.ifconfig',
     'sphinx.ext.intersphinx',
     'sphinx.ext.todo',
     'sphinx.ext.viewcode',
+#    'sphinx.ext.napoleon',
     'numpydoc',
 #    'inheritance_diagram',
-    'sphinx.ext.autosummary'
+    'sphinx.ext.autosummary',
+#    'sphinx_gallery.gen_gallery',
 ]
 #    'matplotlib.sphinxext.plot_directive']
 #    'matplotlib.sphinxext.ipython_directive']
 
+# autodocsumm settings
+#----------------------------------------------------------
+autodoc_default_flags = ['members','undoc-members','show-inheritance']
+autoclass_content = 'both'
+autodata_content = 'call'
+
+add_module_names = True
+#----------------------------------------------------------
+autosummary_generate = False
 # The line below is necessary to stop thousands of warnings
 # see http://stackoverflow.com/a/15210813/732596
 numpydoc_show_class_members = False
 
 # Add any paths that contain templates here, relative to this directory.
-# templates_path = ['_templates']
+templates_path = ['_templates/']
 
 # The suffix of source filenames.
 source_suffix = '.rst'
@@ -181,7 +195,7 @@ html_theme_options = {
 
     # Choose Bootstrap version.
     # Values: "3" (default) or "2" (in quotes)
-#    'bootstrap_version': "3",    
+#    'bootstrap_version': "3",
 }
 
 # Add any paths that contain custom themes here, relative to this directory.
@@ -207,7 +221,7 @@ html_theme_path = sphinx_bootstrap_theme.get_html_theme_path()
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-# html_static_path = ['_static']
+html_static_path = ['_static']
 
 # Add any extra paths that contain custom files (such as robots.txt or
 # .htaccess) here, relative to this directory. These files are copied
@@ -406,3 +420,12 @@ epub_exclude_files = ['search.html']
 
 # If false, no index is generated.
 #epub_use_index = True
+
+# incorporate the copybutton
+def setup(app):
+        app.add_javascript('copybutton.js')
+
+
+
+
+

--- a/docs/source/nilmtk.appliance.rst
+++ b/docs/source/nilmtk.appliance.rst
@@ -1,0 +1,82 @@
+nilmtk\.appliance
+=================
+
+.. topic:: Module summary
+
+    .. automodule:: nilmtk.appliance
+       :no-members:
+       :no-undoc-members:
+       :no-show-inheritance: 
+
+    
+       .. rubric:: Classes
+
+       .. autosummary::
+        
+          Appliance
+          ApplianceID
+    
+
+
+    
+
+
+    
+        
+
+.. topic:: Class: Appliance
+
+    .. autoclass:: Appliance
+       :no-members:
+       :no-undoc-members:
+            
+       .. Note:: This class has inherited methods, see the base class(es) for additional methods
+            
+            
+       .. rubric:: Methods
+
+       .. autosummary::
+                
+            categories
+            label
+            matches
+            on_power_threshold
+            
+            
+       .. rubric:: Attributes
+
+       .. autosummary::
+                
+            allow_synonyms
+            appliance_types
+            identifier
+            n_meters
+            type
+            
+
+.. topic:: Class: ApplianceID
+
+    .. autoclass:: ApplianceID
+       :no-members:
+       :no-undoc-members:
+            
+            
+            
+       .. rubric:: Attributes
+
+       .. autosummary::
+                
+            instance
+            type
+            
+    
+
+
+.. rubric:: Module detail
+
+.. automodule:: nilmtk.appliance
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+

--- a/docs/source/nilmtk.building.rst
+++ b/docs/source/nilmtk.building.rst
@@ -1,0 +1,77 @@
+nilmtk\.building
+================
+
+.. topic:: Module summary
+
+    .. automodule:: nilmtk.building
+       :no-members:
+       :no-undoc-members:
+       :no-show-inheritance: 
+
+    
+       .. rubric:: Classes
+
+       .. autosummary::
+        
+          Building
+          BuildingID
+    
+
+
+    
+
+
+    
+        
+
+.. topic:: Class: Building
+
+    .. autoclass:: Building
+       :no-members:
+       :no-undoc-members:
+            
+       .. Note:: This class has inherited methods, see the base class(es) for additional methods
+            
+            
+       .. rubric:: Methods
+
+       .. autosummary::
+                
+            describe
+            import_metadata
+            save
+            
+            
+       .. rubric:: Attributes
+
+       .. autosummary::
+                
+            identifier
+            
+
+.. topic:: Class: BuildingID
+
+    .. autoclass:: BuildingID
+       :no-members:
+       :no-undoc-members:
+            
+            
+            
+       .. rubric:: Attributes
+
+       .. autosummary::
+                
+            dataset
+            instance
+            
+    
+
+
+.. rubric:: Module detail
+
+.. automodule:: nilmtk.building
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+

--- a/docs/source/nilmtk.consts.rst
+++ b/docs/source/nilmtk.consts.rst
@@ -1,0 +1,7 @@
+nilmtk\.consts module
+=====================
+
+.. automodule:: nilmtk.consts
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/nilmtk.dataset.rst
+++ b/docs/source/nilmtk.dataset.rst
@@ -1,0 +1,58 @@
+nilmtk\.dataset
+===============
+
+.. topic:: Module summary
+
+    .. automodule:: nilmtk.dataset
+       :no-members:
+       :no-undoc-members:
+       :no-show-inheritance: 
+
+    
+       .. rubric:: Classes
+
+       .. autosummary::
+        
+          DataSet
+    
+
+
+    
+
+
+    
+        
+
+.. topic:: Class: DataSet
+
+    .. autoclass:: DataSet
+       :no-members:
+       :no-undoc-members:
+            
+            
+       .. rubric:: Methods
+
+       .. autosummary::
+                
+            clear_cache
+            describe
+            elecs
+            get_activity_script
+            import_metadata
+            plot_good_sections
+            plot_mains_power_histograms
+            save
+            set_window
+            
+            
+    
+
+
+.. rubric:: Module detail
+
+.. automodule:: nilmtk.dataset
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+

--- a/docs/source/nilmtk.dataset_converters.ampds.convert_ampds.rst
+++ b/docs/source/nilmtk.dataset_converters.ampds.convert_ampds.rst
@@ -1,0 +1,7 @@
+nilmtk\.dataset\_converters\.ampds\.convert\_ampds module
+=========================================================
+
+.. automodule:: nilmtk.dataset_converters.ampds.convert_ampds
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/nilmtk.dataset_converters.ampds.rst
+++ b/docs/source/nilmtk.dataset_converters.ampds.rst
@@ -1,22 +1,17 @@
-nilmtk.dataset_converters.ampds package
-=======================================
+nilmtk\.dataset\_converters\.ampds package
+==========================================
+
+Subpackages
+-----------
+
+.. toctree::
+
+    nilmtk.dataset_converters.ampds.metadata
 
 Submodules
 ----------
 
-nilmtk.dataset_converters.ampds.convert_ampds module
-----------------------------------------------------
+.. toctree::
 
-.. automodule:: nilmtk.dataset_converters.ampds.convert_ampds
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   nilmtk.dataset_converters.ampds.convert_ampds
 
-
-Module contents
----------------
-
-.. automodule:: nilmtk.dataset_converters.ampds
-    :members:
-    :undoc-members:
-    :show-inheritance:

--- a/docs/source/nilmtk.dataset_converters.combed.convert_combed.rst
+++ b/docs/source/nilmtk.dataset_converters.combed.convert_combed.rst
@@ -1,0 +1,7 @@
+nilmtk\.dataset\_converters\.combed\.convert\_combed module
+===========================================================
+
+.. automodule:: nilmtk.dataset_converters.combed.convert_combed
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/nilmtk.dataset_converters.combed.download.rst
+++ b/docs/source/nilmtk.dataset_converters.combed.download.rst
@@ -1,0 +1,7 @@
+nilmtk\.dataset\_converters\.combed\.download module
+====================================================
+
+.. automodule:: nilmtk.dataset_converters.combed.download
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/nilmtk.dataset_converters.combed.rst
+++ b/docs/source/nilmtk.dataset_converters.combed.rst
@@ -1,5 +1,5 @@
-nilmtk.dataset_converters.combed package
-========================================
+nilmtk\.dataset\_converters\.combed package
+===========================================
 
 Subpackages
 -----------
@@ -11,27 +11,8 @@ Subpackages
 Submodules
 ----------
 
-nilmtk.dataset_converters.combed.convert_combed module
-------------------------------------------------------
+.. toctree::
 
-.. automodule:: nilmtk.dataset_converters.combed.convert_combed
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   nilmtk.dataset_converters.combed.convert_combed
+   nilmtk.dataset_converters.combed.download
 
-nilmtk.dataset_converters.combed.download module
-------------------------------------------------
-
-.. automodule:: nilmtk.dataset_converters.combed.download
-    :members:
-    :undoc-members:
-    :show-inheritance:
-
-
-Module contents
----------------
-
-.. automodule:: nilmtk.dataset_converters.combed
-    :members:
-    :undoc-members:
-    :show-inheritance:

--- a/docs/source/nilmtk.dataset_converters.dataport.download_dataport.rst
+++ b/docs/source/nilmtk.dataset_converters.dataport.download_dataport.rst
@@ -1,0 +1,7 @@
+nilmtk\.dataset\_converters\.dataport\.download\_dataport module
+================================================================
+
+.. automodule:: nilmtk.dataset_converters.dataport.download_dataport
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/nilmtk.dataset_converters.dataport.rst
+++ b/docs/source/nilmtk.dataset_converters.dataport.rst
@@ -1,22 +1,17 @@
-nilmtk.dataset_converters.dataport package
-==========================================
+nilmtk\.dataset\_converters\.dataport package
+=============================================
+
+Subpackages
+-----------
+
+.. toctree::
+
+    nilmtk.dataset_converters.dataport.metadata
 
 Submodules
 ----------
 
-nilmtk.dataset_converters.dataport.download_dataport module
------------------------------------------------------------
+.. toctree::
 
-.. automodule:: nilmtk.dataset_converters.dataport.download_dataport
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   nilmtk.dataset_converters.dataport.download_dataport
 
-
-Module contents
----------------
-
-.. automodule:: nilmtk.dataset_converters.dataport
-    :members:
-    :undoc-members:
-    :show-inheritance:

--- a/docs/source/nilmtk.dataset_converters.eco.convert_eco.rst
+++ b/docs/source/nilmtk.dataset_converters.eco.convert_eco.rst
@@ -1,0 +1,7 @@
+nilmtk\.dataset\_converters\.eco\.convert\_eco module
+=====================================================
+
+.. automodule:: nilmtk.dataset_converters.eco.convert_eco
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/nilmtk.dataset_converters.eco.rst
+++ b/docs/source/nilmtk.dataset_converters.eco.rst
@@ -1,22 +1,17 @@
-nilmtk.dataset_converters.eco package
-=====================================
+nilmtk\.dataset\_converters\.eco package
+========================================
+
+Subpackages
+-----------
+
+.. toctree::
+
+    nilmtk.dataset_converters.eco.metadata
 
 Submodules
 ----------
 
-nilmtk.dataset_converters.eco.convert_eco module
-------------------------------------------------
+.. toctree::
 
-.. automodule:: nilmtk.dataset_converters.eco.convert_eco
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   nilmtk.dataset_converters.eco.convert_eco
 
-
-Module contents
----------------
-
-.. automodule:: nilmtk.dataset_converters.eco
-    :members:
-    :undoc-members:
-    :show-inheritance:

--- a/docs/source/nilmtk.dataset_converters.greend.convert_greend.rst
+++ b/docs/source/nilmtk.dataset_converters.greend.convert_greend.rst
@@ -1,0 +1,7 @@
+nilmtk\.dataset\_converters\.greend\.convert\_greend module
+===========================================================
+
+.. automodule:: nilmtk.dataset_converters.greend.convert_greend
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/nilmtk.dataset_converters.greend.rst
+++ b/docs/source/nilmtk.dataset_converters.greend.rst
@@ -1,22 +1,17 @@
-nilmtk.dataset_converters.greend package
-========================================
+nilmtk\.dataset\_converters\.greend package
+===========================================
+
+Subpackages
+-----------
+
+.. toctree::
+
+    nilmtk.dataset_converters.greend.metadata
 
 Submodules
 ----------
 
-nilmtk.dataset_converters.greend.convert_greend module
-------------------------------------------------------
+.. toctree::
 
-.. automodule:: nilmtk.dataset_converters.greend.convert_greend
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   nilmtk.dataset_converters.greend.convert_greend
 
-
-Module contents
----------------
-
-.. automodule:: nilmtk.dataset_converters.greend
-    :members:
-    :undoc-members:
-    :show-inheritance:

--- a/docs/source/nilmtk.dataset_converters.hes.convert_hes.rst
+++ b/docs/source/nilmtk.dataset_converters.hes.convert_hes.rst
@@ -1,0 +1,7 @@
+nilmtk\.dataset\_converters\.hes\.convert\_hes module
+=====================================================
+
+.. automodule:: nilmtk.dataset_converters.hes.convert_hes
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/nilmtk.dataset_converters.hes.rst
+++ b/docs/source/nilmtk.dataset_converters.hes.rst
@@ -1,22 +1,17 @@
-nilmtk.dataset_converters.hes package
-=====================================
+nilmtk\.dataset\_converters\.hes package
+========================================
+
+Subpackages
+-----------
+
+.. toctree::
+
+    nilmtk.dataset_converters.hes.metadata
 
 Submodules
 ----------
 
-nilmtk.dataset_converters.hes.convert_hes module
-------------------------------------------------
+.. toctree::
 
-.. automodule:: nilmtk.dataset_converters.hes.convert_hes
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   nilmtk.dataset_converters.hes.convert_hes
 
-
-Module contents
----------------
-
-.. automodule:: nilmtk.dataset_converters.hes
-    :members:
-    :undoc-members:
-    :show-inheritance:

--- a/docs/source/nilmtk.dataset_converters.iawe.convert_iawe.rst
+++ b/docs/source/nilmtk.dataset_converters.iawe.convert_iawe.rst
@@ -1,0 +1,7 @@
+nilmtk\.dataset\_converters\.iawe\.convert\_iawe module
+=======================================================
+
+.. automodule:: nilmtk.dataset_converters.iawe.convert_iawe
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/nilmtk.dataset_converters.iawe.rst
+++ b/docs/source/nilmtk.dataset_converters.iawe.rst
@@ -1,5 +1,5 @@
-nilmtk.dataset_converters.iawe package
-======================================
+nilmtk\.dataset\_converters\.iawe package
+=========================================
 
 Subpackages
 -----------
@@ -11,19 +11,7 @@ Subpackages
 Submodules
 ----------
 
-nilmtk.dataset_converters.iawe.convert_iawe module
---------------------------------------------------
+.. toctree::
 
-.. automodule:: nilmtk.dataset_converters.iawe.convert_iawe
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   nilmtk.dataset_converters.iawe.convert_iawe
 
-
-Module contents
----------------
-
-.. automodule:: nilmtk.dataset_converters.iawe
-    :members:
-    :undoc-members:
-    :show-inheritance:

--- a/docs/source/nilmtk.dataset_converters.redd.convert_redd.rst
+++ b/docs/source/nilmtk.dataset_converters.redd.convert_redd.rst
@@ -1,0 +1,7 @@
+nilmtk\.dataset\_converters\.redd\.convert\_redd module
+=======================================================
+
+.. automodule:: nilmtk.dataset_converters.redd.convert_redd
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/nilmtk.dataset_converters.redd.rst
+++ b/docs/source/nilmtk.dataset_converters.redd.rst
@@ -1,22 +1,17 @@
-nilmtk.dataset_converters.redd package
-======================================
+nilmtk\.dataset\_converters\.redd package
+=========================================
+
+Subpackages
+-----------
+
+.. toctree::
+
+    nilmtk.dataset_converters.redd.metadata
 
 Submodules
 ----------
 
-nilmtk.dataset_converters.redd.convert_redd module
---------------------------------------------------
+.. toctree::
 
-.. automodule:: nilmtk.dataset_converters.redd.convert_redd
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   nilmtk.dataset_converters.redd.convert_redd
 
-
-Module contents
----------------
-
-.. automodule:: nilmtk.dataset_converters.redd
-    :members:
-    :undoc-members:
-    :show-inheritance:

--- a/docs/source/nilmtk.dataset_converters.refit.convert_refit.rst
+++ b/docs/source/nilmtk.dataset_converters.refit.convert_refit.rst
@@ -1,0 +1,7 @@
+nilmtk\.dataset\_converters\.refit\.convert\_refit module
+=========================================================
+
+.. automodule:: nilmtk.dataset_converters.refit.convert_refit
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/nilmtk.dataset_converters.refit.rst
+++ b/docs/source/nilmtk.dataset_converters.refit.rst
@@ -1,0 +1,17 @@
+nilmtk\.dataset\_converters\.refit package
+==========================================
+
+Subpackages
+-----------
+
+.. toctree::
+
+    nilmtk.dataset_converters.refit.metadata
+
+Submodules
+----------
+
+.. toctree::
+
+   nilmtk.dataset_converters.refit.convert_refit
+

--- a/docs/source/nilmtk.dataset_converters.rst
+++ b/docs/source/nilmtk.dataset_converters.rst
@@ -1,5 +1,5 @@
-nilmtk.dataset_converters package
-=================================
+nilmtk\.dataset\_converters package
+===================================
 
 Subpackages
 -----------
@@ -14,12 +14,6 @@ Subpackages
     nilmtk.dataset_converters.hes
     nilmtk.dataset_converters.iawe
     nilmtk.dataset_converters.redd
+    nilmtk.dataset_converters.refit
     nilmtk.dataset_converters.ukdale
 
-Module contents
----------------
-
-.. automodule:: nilmtk.dataset_converters
-    :members:
-    :undoc-members:
-    :show-inheritance:

--- a/docs/source/nilmtk.dataset_converters.ukdale.convert_ukdale.rst
+++ b/docs/source/nilmtk.dataset_converters.ukdale.convert_ukdale.rst
@@ -1,0 +1,7 @@
+nilmtk\.dataset\_converters\.ukdale\.convert\_ukdale module
+===========================================================
+
+.. automodule:: nilmtk.dataset_converters.ukdale.convert_ukdale
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/nilmtk.dataset_converters.ukdale.rst
+++ b/docs/source/nilmtk.dataset_converters.ukdale.rst
@@ -1,22 +1,10 @@
-nilmtk.dataset_converters.ukdale package
-========================================
+nilmtk\.dataset\_converters\.ukdale package
+===========================================
 
 Submodules
 ----------
 
-nilmtk.dataset_converters.ukdale.convert_ukdale module
-------------------------------------------------------
+.. toctree::
 
-.. automodule:: nilmtk.dataset_converters.ukdale.convert_ukdale
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   nilmtk.dataset_converters.ukdale.convert_ukdale
 
-
-Module contents
----------------
-
-.. automodule:: nilmtk.dataset_converters.ukdale
-    :members:
-    :undoc-members:
-    :show-inheritance:

--- a/docs/source/nilmtk.datastore.csvdatastore.rst
+++ b/docs/source/nilmtk.datastore.csvdatastore.rst
@@ -1,0 +1,7 @@
+nilmtk\.datastore\.csvdatastore module
+======================================
+
+.. automodule:: nilmtk.datastore.csvdatastore
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/nilmtk.datastore.datastore.rst
+++ b/docs/source/nilmtk.datastore.datastore.rst
@@ -1,0 +1,73 @@
+nilmtk\.datastore\.datastore
+============================
+
+.. topic:: Module summary
+
+    .. automodule:: nilmtk.datastore.datastore
+       :no-members:
+       :no-undoc-members:
+       :no-show-inheritance: 
+
+       .. rubric:: Functions
+
+       .. autosummary::
+
+          convert_datastore
+          join_key
+          write_yaml_to_file
+
+    
+       .. rubric:: Classes
+
+       .. autosummary::
+        
+          DataStore
+    
+
+
+    
+
+
+    
+        
+
+.. topic:: Class: DataStore
+
+    .. autoclass:: DataStore
+       :no-members:
+       :no-undoc-members:
+            
+            
+       .. rubric:: Methods
+
+       .. autosummary::
+                
+            append
+            close
+            elements_below_key
+            get_timeframe
+            load
+            load_metadata
+            open
+            put
+            remove
+            save_metadata
+            
+            
+       .. rubric:: Attributes
+
+       .. autosummary::
+                
+            window
+            
+    
+
+
+.. rubric:: Module detail
+
+.. automodule:: nilmtk.datastore.datastore
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+

--- a/docs/source/nilmtk.datastore.hdfdatastore.rst
+++ b/docs/source/nilmtk.datastore.hdfdatastore.rst
@@ -1,0 +1,7 @@
+nilmtk\.datastore\.hdfdatastore module
+======================================
+
+.. automodule:: nilmtk.datastore.hdfdatastore
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/nilmtk.datastore.key.rst
+++ b/docs/source/nilmtk.datastore.key.rst
@@ -1,0 +1,7 @@
+nilmtk\.datastore\.key module
+=============================
+
+.. automodule:: nilmtk.datastore.key
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/nilmtk.datastore.rst
+++ b/docs/source/nilmtk.datastore.rst
@@ -1,46 +1,13 @@
-nilmtk.datastore package
-========================
+nilmtk\.datastore package
+=========================
 
 Submodules
 ----------
 
-nilmtk.datastore.csvdatastore module
-------------------------------------
+.. toctree::
 
-.. automodule:: nilmtk.datastore.csvdatastore
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   nilmtk.datastore.csvdatastore
+   nilmtk.datastore.datastore
+   nilmtk.datastore.hdfdatastore
+   nilmtk.datastore.key
 
-nilmtk.datastore.datastore module
----------------------------------
-
-.. automodule:: nilmtk.datastore.datastore
-    :members:
-    :undoc-members:
-    :show-inheritance:
-
-nilmtk.datastore.hdfdatastore module
-------------------------------------
-
-.. automodule:: nilmtk.datastore.hdfdatastore
-    :members:
-    :undoc-members:
-    :show-inheritance:
-
-nilmtk.datastore.key module
----------------------------
-
-.. automodule:: nilmtk.datastore.key
-    :members:
-    :undoc-members:
-    :show-inheritance:
-
-
-Module contents
----------------
-
-.. automodule:: nilmtk.datastore
-    :members:
-    :undoc-members:
-    :show-inheritance:

--- a/docs/source/nilmtk.disaggregate.combinatorial_optimisation.rst
+++ b/docs/source/nilmtk.disaggregate.combinatorial_optimisation.rst
@@ -1,0 +1,57 @@
+nilmtk\.disaggregate\.combinatorial\_optimisation
+=================================================
+
+.. topic:: Module summary
+
+    .. automodule:: nilmtk.disaggregate.combinatorial_optimisation
+       :no-members:
+       :no-undoc-members:
+       :no-show-inheritance: 
+
+    
+       .. rubric:: Classes
+
+       .. autosummary::
+        
+          CombinatorialOptimisation
+    
+
+
+    
+
+
+    
+        
+
+.. topic:: Class: CombinatorialOptimisation
+
+    .. autoclass:: CombinatorialOptimisation
+       :no-members:
+       :no-undoc-members:
+            
+       .. Note:: This class has inherited methods, see the base class(es) for additional methods
+            
+            
+       .. rubric:: Methods
+
+       .. autosummary::
+                
+            disaggregate
+            disaggregate_chunk
+            export_model
+            import_model
+            train
+            train_on_chunk
+            
+            
+    
+
+
+.. rubric:: Module detail
+
+.. automodule:: nilmtk.disaggregate.combinatorial_optimisation
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+

--- a/docs/source/nilmtk.disaggregate.disaggregator.rst
+++ b/docs/source/nilmtk.disaggregate.disaggregator.rst
@@ -1,0 +1,55 @@
+nilmtk\.disaggregate\.disaggregator
+===================================
+
+.. topic:: Module summary
+
+    .. automodule:: nilmtk.disaggregate.disaggregator
+       :no-members:
+       :no-undoc-members:
+       :no-show-inheritance: 
+
+    
+       .. rubric:: Classes
+
+       .. autosummary::
+        
+          Disaggregator
+    
+
+
+    
+
+
+    
+        
+
+.. topic:: Class: Disaggregator
+
+    .. autoclass:: Disaggregator
+       :no-members:
+       :no-undoc-members:
+            
+            
+       .. rubric:: Methods
+
+       .. autosummary::
+                
+            disaggregate
+            disaggregate_chunk
+            export_model
+            import_model
+            train
+            train_on_chunk
+            
+            
+    
+
+
+.. rubric:: Module detail
+
+.. automodule:: nilmtk.disaggregate.disaggregator
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+

--- a/docs/source/nilmtk.disaggregate.fhmm_exact.rst
+++ b/docs/source/nilmtk.disaggregate.fhmm_exact.rst
@@ -1,0 +1,71 @@
+nilmtk\.disaggregate\.fhmm\_exact
+=================================
+
+.. topic:: Module summary
+
+    .. automodule:: nilmtk.disaggregate.fhmm_exact
+       :no-members:
+       :no-undoc-members:
+       :no-show-inheritance: 
+
+       .. rubric:: Functions
+
+       .. autosummary::
+
+          compute_A_fhmm
+          compute_means_fhmm
+          compute_pi_fhmm
+          create_combined_hmm
+          decode_hmm
+          return_sorting_mapping
+          sort_covars
+          sort_learnt_parameters
+          sort_startprob
+          sort_transition_matrix
+
+    
+       .. rubric:: Classes
+
+       .. autosummary::
+        
+          FHMM
+    
+
+
+    
+
+
+    
+        
+
+.. topic:: Class: FHMM
+
+    .. autoclass:: FHMM
+       :no-members:
+       :no-undoc-members:
+            
+       .. Note:: This class has inherited methods, see the base class(es) for additional methods
+            
+            
+       .. rubric:: Methods
+
+       .. autosummary::
+                
+            disaggregate
+            disaggregate_across_buildings
+            disaggregate_chunk
+            train
+            train_across_buildings
+            
+            
+    
+
+
+.. rubric:: Module detail
+
+.. automodule:: nilmtk.disaggregate.fhmm_exact
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+

--- a/docs/source/nilmtk.disaggregate.hart_85.rst
+++ b/docs/source/nilmtk.disaggregate.hart_85.rst
@@ -1,0 +1,96 @@
+nilmtk\.disaggregate\.hart\_85
+==============================
+
+.. topic:: Module summary
+
+    .. automodule:: nilmtk.disaggregate.hart_85
+       :no-members:
+       :no-undoc-members:
+       :no-show-inheritance: 
+
+    
+       .. rubric:: Classes
+
+       .. autosummary::
+        
+          Hart85
+          MyDeque
+          PairBuffer
+    
+
+
+    
+
+
+    
+        
+
+.. topic:: Class: Hart85
+
+    .. autoclass:: Hart85
+       :no-members:
+       :no-undoc-members:
+            
+       .. Note:: This class has inherited methods, see the base class(es) for additional methods
+            
+            
+       .. rubric:: Methods
+
+       .. autosummary::
+                
+            assign_power_from_states
+            disaggregate
+            disaggregate_chunk
+            pair
+            train
+            
+            
+
+.. topic:: Class: MyDeque
+
+    .. autoclass:: MyDeque
+       :no-members:
+       :no-undoc-members:
+            
+            
+       .. rubric:: Methods
+
+       .. autosummary::
+                
+            popmiddle
+            
+            
+       .. rubric:: Attributes
+
+       .. autosummary::
+                
+            maxlen
+            
+
+.. topic:: Class: PairBuffer
+
+    .. autoclass:: PairBuffer
+       :no-members:
+       :no-undoc-members:
+            
+            
+       .. rubric:: Methods
+
+       .. autosummary::
+                
+            add_transition
+            clean_buffer
+            pair_transitions
+            
+            
+    
+
+
+.. rubric:: Module detail
+
+.. automodule:: nilmtk.disaggregate.hart_85
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+

--- a/docs/source/nilmtk.disaggregate.maximum_likelihood_estimation.rst
+++ b/docs/source/nilmtk.disaggregate.maximum_likelihood_estimation.rst
@@ -1,0 +1,60 @@
+nilmtk\.disaggregate\.maximum\_likelihood\_estimation
+=====================================================
+
+.. topic:: Module summary
+
+    .. automodule:: nilmtk.disaggregate.maximum_likelihood_estimation
+       :no-members:
+       :no-undoc-members:
+       :no-show-inheritance: 
+
+    
+       .. rubric:: Classes
+
+       .. autosummary::
+        
+          MLE
+    
+
+
+    
+
+
+    
+        
+
+.. topic:: Class: MLE
+
+    .. autoclass:: MLE
+       :no-members:
+       :no-undoc-members:
+            
+       .. Note:: This class has inherited methods, see the base class(es) for additional methods
+            
+            
+       .. rubric:: Methods
+
+       .. autosummary::
+                
+            check_cdfIntegrity
+            disaggregate
+            disaggregate_chunk
+            featuresHist
+            featuresHist_colors
+            no_overfitting
+            train
+            train_on_chunk
+            update
+            
+            
+    
+
+
+.. rubric:: Module detail
+
+.. automodule:: nilmtk.disaggregate.maximum_likelihood_estimation
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+

--- a/docs/source/nilmtk.disaggregate.rst
+++ b/docs/source/nilmtk.disaggregate.rst
@@ -1,46 +1,14 @@
-nilmtk.disaggregate package
-===========================
+nilmtk\.disaggregate package
+============================
 
 Submodules
 ----------
 
-nilmtk.disaggregate.combinatorial_optimisation module
------------------------------------------------------
+.. toctree::
 
-.. automodule:: nilmtk.disaggregate.combinatorial_optimisation
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   nilmtk.disaggregate.combinatorial_optimisation
+   nilmtk.disaggregate.disaggregator
+   nilmtk.disaggregate.fhmm_exact
+   nilmtk.disaggregate.hart_85
+   nilmtk.disaggregate.maximum_likelihood_estimation
 
-nilmtk.disaggregate.disaggregator module
-----------------------------------------
-
-.. automodule:: nilmtk.disaggregate.disaggregator
-    :members:
-    :undoc-members:
-    :show-inheritance:
-
-nilmtk.disaggregate.fhmm_exact module
--------------------------------------
-
-.. automodule:: nilmtk.disaggregate.fhmm_exact
-    :members:
-    :undoc-members:
-    :show-inheritance:
-
-nilmtk.disaggregate.hart_85 module
-----------------------------------
-
-.. automodule:: nilmtk.disaggregate.hart_85
-    :members:
-    :undoc-members:
-    :show-inheritance:
-
-
-Module contents
----------------
-
-.. automodule:: nilmtk.disaggregate
-    :members:
-    :undoc-members:
-    :show-inheritance:

--- a/docs/source/nilmtk.docinherit.rst
+++ b/docs/source/nilmtk.docinherit.rst
@@ -1,0 +1,70 @@
+nilmtk\.docinherit
+==================
+
+.. topic:: Module summary
+
+    .. automodule:: nilmtk.docinherit
+       :no-members:
+       :no-undoc-members:
+       :no-show-inheritance: 
+
+    
+       .. rubric:: Classes
+
+       .. autosummary::
+        
+          DocInherit
+          doc_inherit
+    
+
+
+    
+
+
+    
+        
+
+.. topic:: Class: DocInherit
+
+    .. autoclass:: DocInherit
+       :no-members:
+       :no-undoc-members:
+            
+            
+       .. rubric:: Methods
+
+       .. autosummary::
+                
+            get_no_inst
+            get_with_inst
+            use_parent_doc
+            
+            
+
+.. topic:: Class: doc_inherit
+
+    .. autoclass:: doc_inherit
+       :no-members:
+       :no-undoc-members:
+            
+            
+       .. rubric:: Methods
+
+       .. autosummary::
+                
+            get_no_inst
+            get_with_inst
+            use_parent_doc
+            
+            
+    
+
+
+.. rubric:: Module detail
+
+.. automodule:: nilmtk.docinherit
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+

--- a/docs/source/nilmtk.elecmeter.rst
+++ b/docs/source/nilmtk.elecmeter.rst
@@ -1,0 +1,102 @@
+nilmtk\.elecmeter
+=================
+
+.. topic:: Module summary
+
+    .. automodule:: nilmtk.elecmeter
+       :no-members:
+       :no-undoc-members:
+       :no-show-inheritance: 
+
+    
+       .. rubric:: Classes
+
+       .. autosummary::
+        
+          ElecMeter
+          ElecMeterID
+    
+
+
+    
+
+
+    
+        
+
+.. topic:: Class: ElecMeter
+
+    .. autoclass:: ElecMeter
+       :no-members:
+       :no-undoc-members:
+            
+       .. Note:: This class has inherited methods, see the base class(es) for additional methods
+            
+            
+       .. rubric:: Methods
+
+       .. autosummary::
+                
+            available_ac_types
+            available_columns
+            available_physical_quantities
+            building
+            clear_cache
+            dataset
+            dominant_appliance
+            dropout_rate
+            dry_run_metadata
+            get_cached_stat
+            get_metadata
+            get_source_node
+            get_timeframe
+            good_sections
+            instance
+            is_site_meter
+            key_for_cached_stat
+            label
+            load
+            matches
+            sample_period
+            save
+            total_energy
+            upstream_meter
+            
+            
+       .. rubric:: Attributes
+
+       .. autosummary::
+                
+            device
+            key
+            meter_devices
+            name
+            
+
+.. topic:: Class: ElecMeterID
+
+    .. autoclass:: ElecMeterID
+       :no-members:
+       :no-undoc-members:
+            
+            
+            
+       .. rubric:: Attributes
+
+       .. autosummary::
+                
+            building
+            dataset
+            instance
+            
+    
+
+
+.. rubric:: Module detail
+
+.. automodule:: nilmtk.elecmeter
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+

--- a/docs/source/nilmtk.electric.rst
+++ b/docs/source/nilmtk.electric.rst
@@ -1,0 +1,85 @@
+nilmtk\.electric
+================
+
+.. topic:: Module summary
+
+    .. automodule:: nilmtk.electric
+       :no-members:
+       :no-undoc-members:
+       :no-show-inheritance: 
+
+       .. rubric:: Functions
+
+       .. autosummary::
+
+          activation_series_for_chunk
+          align_two_meters
+          get_activations
+          get_vampire_power
+
+    
+       .. rubric:: Classes
+
+       .. autosummary::
+        
+          Electric
+    
+
+
+    
+
+
+    
+        
+
+.. topic:: Class: Electric
+
+    .. autoclass:: Electric
+       :no-members:
+       :no-undoc-members:
+            
+            
+       .. rubric:: Methods
+
+       .. autosummary::
+                
+            activation_series
+            activity_histogram
+            available_power_ac_types
+            average_energy_per_period
+            correlation
+            entropy
+            get_activations
+            load_series
+            matches_appliances
+            min_off_duration
+            min_on_duration
+            mutual_information
+            on_power_threshold
+            plot
+            plot_activity_histogram
+            plot_autocorrelation
+            plot_lag
+            plot_power_histogram
+            plot_spectrum
+            power_series
+            power_series_all_data
+            proportion_of_energy
+            proportion_of_upstream
+            switch_times
+            uptime
+            vampire_power
+            when_on
+            
+            
+    
+
+
+.. rubric:: Module detail
+
+.. automodule:: nilmtk.electric
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+

--- a/docs/source/nilmtk.exceptions.rst
+++ b/docs/source/nilmtk.exceptions.rst
@@ -1,0 +1,7 @@
+nilmtk\.exceptions module
+=========================
+
+.. automodule:: nilmtk.exceptions
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/nilmtk.feature_detectors.cluster.rst
+++ b/docs/source/nilmtk.feature_detectors.cluster.rst
@@ -1,0 +1,7 @@
+nilmtk\.feature\_detectors\.cluster module
+==========================================
+
+.. automodule:: nilmtk.feature_detectors.cluster
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/nilmtk.feature_detectors.rst
+++ b/docs/source/nilmtk.feature_detectors.rst
@@ -1,30 +1,11 @@
-nilmtk.feature_detectors package
-================================
+nilmtk\.feature\_detectors package
+==================================
 
 Submodules
 ----------
 
-nilmtk.feature_detectors.cluster module
----------------------------------------
+.. toctree::
 
-.. automodule:: nilmtk.feature_detectors.cluster
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   nilmtk.feature_detectors.cluster
+   nilmtk.feature_detectors.steady_states
 
-nilmtk.feature_detectors.steady_states module
----------------------------------------------
-
-.. automodule:: nilmtk.feature_detectors.steady_states
-    :members:
-    :undoc-members:
-    :show-inheritance:
-
-
-Module contents
----------------
-
-.. automodule:: nilmtk.feature_detectors
-    :members:
-    :undoc-members:
-    :show-inheritance:

--- a/docs/source/nilmtk.feature_detectors.steady_states.rst
+++ b/docs/source/nilmtk.feature_detectors.steady_states.rst
@@ -1,0 +1,7 @@
+nilmtk\.feature\_detectors\.steady\_states module
+=================================================
+
+.. automodule:: nilmtk.feature_detectors.steady_states
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/nilmtk.hashable.rst
+++ b/docs/source/nilmtk.hashable.rst
@@ -1,0 +1,7 @@
+nilmtk\.hashable module
+=======================
+
+.. automodule:: nilmtk.hashable
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/nilmtk.measurement.rst
+++ b/docs/source/nilmtk.measurement.rst
@@ -1,0 +1,7 @@
+nilmtk\.measurement module
+==========================
+
+.. automodule:: nilmtk.measurement
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/nilmtk.metergroup.rst
+++ b/docs/source/nilmtk.metergroup.rst
@@ -1,0 +1,138 @@
+nilmtk\.metergroup
+==================
+
+.. topic:: Module summary
+
+    .. automodule:: nilmtk.metergroup
+       :no-members:
+       :no-undoc-members:
+       :no-show-inheritance: 
+
+       .. rubric:: Functions
+
+       .. autosummary::
+
+          combine_chunks_from_generators
+          iterate_through_submeters_of_two_metergroups
+          meter_sorting_key
+          replace_dataset
+
+    
+       .. rubric:: Classes
+
+       .. autosummary::
+        
+          MeterGroup
+          MeterGroupID
+    
+
+
+    
+
+
+    
+        
+
+.. topic:: Class: MeterGroup
+
+    .. autoclass:: MeterGroup
+       :no-members:
+       :no-undoc-members:
+            
+       .. Note:: This class has inherited methods, see the base class(es) for additional methods
+            
+            
+       .. rubric:: Methods
+
+       .. autosummary::
+                
+            all_meters
+            available_ac_types
+            available_physical_quantities
+            building
+            call_method_on_all_meters
+            clear_cache
+            contains_meters_from_multiple_buildings
+            correlation_of_sum_of_submeters_with_mains
+            dataframe_of_meters
+            dataset
+            describe
+            dominant_appliance
+            dominant_appliances
+            draw_wiring_graph
+            dropout_rate
+            energy_per_meter
+            entropy_per_meter
+            fraction_per_meter
+            from_list
+            get_labels
+            get_timeframe
+            good_sections
+            groupby
+            import_metadata
+            instance
+            is_site_meter
+            label
+            load
+            mains
+            matches
+            meters_directly_downstream_of_mains
+            nested_metergroups
+            pairwise
+            pairwise_correlation
+            pairwise_mutual_information
+            plot
+            plot_good_sections
+            plot_multiple
+            plot_when_on
+            proportion_of_energy_submetered
+            proportion_of_upstream_total_per_meter
+            sample_period
+            select
+            select_top_k
+            select_using_appliances
+            simultaneous_switches
+            sort_meters
+            submeters
+            total_energy
+            train_test_split
+            union
+            upstream_meter
+            use_alternative_mains
+            values_for_appliance_metadata_key
+            wiring_graph
+            
+            
+       .. rubric:: Attributes
+
+       .. autosummary::
+                
+            appliances
+            identifier
+            
+
+.. topic:: Class: MeterGroupID
+
+    .. autoclass:: MeterGroupID
+       :no-members:
+       :no-undoc-members:
+            
+            
+            
+       .. rubric:: Attributes
+
+       .. autosummary::
+                
+            meters
+            
+    
+
+
+.. rubric:: Module detail
+
+.. automodule:: nilmtk.metergroup
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+

--- a/docs/source/nilmtk.metrics.rst
+++ b/docs/source/nilmtk.metrics.rst
@@ -1,0 +1,37 @@
+nilmtk\.metrics
+===============
+
+.. topic:: Module summary
+
+    .. automodule:: nilmtk.metrics
+       :no-members:
+       :no-undoc-members:
+       :no-show-inheritance: 
+
+       .. rubric:: Functions
+
+       .. autosummary::
+
+          error_in_assigned_energy
+          f1_score
+          fraction_energy_assigned_correctly
+          mean_normalized_error_power
+          rms_error_power
+
+    
+
+
+    
+
+
+    
+
+
+.. rubric:: Module detail
+
+.. automodule:: nilmtk.metrics
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+

--- a/docs/source/nilmtk.node.rst
+++ b/docs/source/nilmtk.node.rst
@@ -1,0 +1,70 @@
+nilmtk\.node
+============
+
+.. topic:: Module summary
+
+    .. automodule:: nilmtk.node
+       :no-members:
+       :no-undoc-members:
+       :no-show-inheritance: 
+
+       .. rubric:: Functions
+
+       .. autosummary::
+
+          find_unsatisfied_requirements
+
+    
+       .. rubric:: Classes
+
+       .. autosummary::
+        
+          Node
+    
+
+
+    
+
+
+    
+        
+
+.. topic:: Class: Node
+
+    .. autoclass:: Node
+       :no-members:
+       :no-undoc-members:
+            
+            
+       .. rubric:: Methods
+
+       .. autosummary::
+                
+            check_requirements
+            dry_run_metadata
+            get_metadata
+            process
+            required_measurements
+            reset
+            run
+            
+            
+       .. rubric:: Attributes
+
+       .. autosummary::
+                
+            postconditions
+            requirements
+            results_class
+            
+    
+
+
+.. rubric:: Module detail
+
+.. automodule:: nilmtk.node
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+

--- a/docs/source/nilmtk.plots.rst
+++ b/docs/source/nilmtk.plots.rst
@@ -1,0 +1,7 @@
+nilmtk\.plots module
+====================
+
+.. automodule:: nilmtk.plots
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/nilmtk.preprocessing.apply.rst
+++ b/docs/source/nilmtk.preprocessing.apply.rst
@@ -1,0 +1,60 @@
+nilmtk\.preprocessing\.apply
+============================
+
+.. topic:: Module summary
+
+    .. automodule:: nilmtk.preprocessing.apply
+       :no-members:
+       :no-undoc-members:
+       :no-show-inheritance: 
+
+    
+       .. rubric:: Classes
+
+       .. autosummary::
+        
+          Apply
+    
+
+
+    
+
+
+    
+        
+
+.. topic:: Class: Apply
+
+    .. autoclass:: Apply
+       :no-members:
+       :no-undoc-members:
+            
+       .. Note:: This class has inherited methods, see the base class(es) for additional methods
+            
+            
+       .. rubric:: Methods
+
+       .. autosummary::
+                
+            process
+            
+            
+       .. rubric:: Attributes
+
+       .. autosummary::
+                
+            postconditions
+            requirements
+            results_class
+            
+    
+
+
+.. rubric:: Module detail
+
+.. automodule:: nilmtk.preprocessing.apply
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+

--- a/docs/source/nilmtk.preprocessing.clip.rst
+++ b/docs/source/nilmtk.preprocessing.clip.rst
@@ -1,0 +1,61 @@
+nilmtk\.preprocessing\.clip
+===========================
+
+.. topic:: Module summary
+
+    .. automodule:: nilmtk.preprocessing.clip
+       :no-members:
+       :no-undoc-members:
+       :no-show-inheritance: 
+
+    
+       .. rubric:: Classes
+
+       .. autosummary::
+        
+          Clip
+    
+
+
+    
+
+
+    
+        
+
+.. topic:: Class: Clip
+
+    .. autoclass:: Clip
+       :no-members:
+       :no-undoc-members:
+            
+       .. Note:: This class has inherited methods, see the base class(es) for additional methods
+            
+            
+       .. rubric:: Methods
+
+       .. autosummary::
+                
+            process
+            reset
+            
+            
+       .. rubric:: Attributes
+
+       .. autosummary::
+                
+            postconditions
+            requirements
+            results_class
+            
+    
+
+
+.. rubric:: Module detail
+
+.. automodule:: nilmtk.preprocessing.clip
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+

--- a/docs/source/nilmtk.preprocessing.rst
+++ b/docs/source/nilmtk.preprocessing.rst
@@ -1,5 +1,5 @@
-nilmtk.preprocessing package
-============================
+nilmtk\.preprocessing package
+=============================
 
 Subpackages
 -----------
@@ -11,27 +11,8 @@ Subpackages
 Submodules
 ----------
 
-nilmtk.preprocessing.apply module
----------------------------------
+.. toctree::
 
-.. automodule:: nilmtk.preprocessing.apply
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   nilmtk.preprocessing.apply
+   nilmtk.preprocessing.clip
 
-nilmtk.preprocessing.clip module
---------------------------------
-
-.. automodule:: nilmtk.preprocessing.clip
-    :members:
-    :undoc-members:
-    :show-inheritance:
-
-
-Module contents
----------------
-
-.. automodule:: nilmtk.preprocessing
-    :members:
-    :undoc-members:
-    :show-inheritance:

--- a/docs/source/nilmtk.results.rst
+++ b/docs/source/nilmtk.results.rst
@@ -1,0 +1,59 @@
+nilmtk\.results
+===============
+
+.. topic:: Module summary
+
+    .. automodule:: nilmtk.results
+       :no-members:
+       :no-undoc-members:
+       :no-show-inheritance: 
+
+    
+       .. rubric:: Classes
+
+       .. autosummary::
+        
+          Results
+    
+
+
+    
+
+
+    
+        
+
+.. topic:: Class: Results
+
+    .. autoclass:: Results
+       :no-members:
+       :no-undoc-members:
+            
+            
+       .. rubric:: Methods
+
+       .. autosummary::
+                
+            append
+            check_for_overlap
+            combined
+            export_to_cache
+            import_from_cache
+            per_period
+            simple
+            timeframes
+            unify
+            update
+            
+            
+    
+
+
+.. rubric:: Module detail
+
+.. automodule:: nilmtk.results
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+

--- a/docs/source/nilmtk.rst
+++ b/docs/source/nilmtk.rst
@@ -17,158 +17,27 @@ Subpackages
 Submodules
 ----------
 
-nilmtk.appliance module
------------------------
+.. toctree::
 
-.. automodule:: nilmtk.appliance
-    :members:
-    :undoc-members:
-    :show-inheritance:
-
-nilmtk.building module
-----------------------
-
-.. automodule:: nilmtk.building
-    :members:
-    :undoc-members:
-    :show-inheritance:
-
-nilmtk.consts module
---------------------
-
-.. automodule:: nilmtk.consts
-    :members:
-    :undoc-members:
-    :show-inheritance:
-
-nilmtk.dataset module
----------------------
-
-.. automodule:: nilmtk.dataset
-    :members:
-    :undoc-members:
-    :show-inheritance:
-
-nilmtk.docinherit module
-------------------------
-
-.. automodule:: nilmtk.docinherit
-    :members:
-    :undoc-members:
-    :show-inheritance:
-
-nilmtk.elecmeter module
------------------------
-
-.. automodule:: nilmtk.elecmeter
-    :members:
-    :undoc-members:
-    :show-inheritance:
-
-nilmtk.electric module
-----------------------
-
-.. automodule:: nilmtk.electric
-    :members:
-    :undoc-members:
-    :show-inheritance:
-
-nilmtk.exceptions module
-------------------------
-
-.. automodule:: nilmtk.exceptions
-    :members:
-    :undoc-members:
-    :show-inheritance:
-
-nilmtk.hashable module
-----------------------
-
-.. automodule:: nilmtk.hashable
-    :members:
-    :undoc-members:
-    :show-inheritance:
-
-nilmtk.measurement module
--------------------------
-
-.. automodule:: nilmtk.measurement
-    :members:
-    :undoc-members:
-    :show-inheritance:
-
-nilmtk.metergroup module
-------------------------
-
-.. automodule:: nilmtk.metergroup
-    :members:
-    :undoc-members:
-    :show-inheritance:
-
-nilmtk.metrics module
----------------------
-
-.. automodule:: nilmtk.metrics
-    :members:
-    :undoc-members:
-    :show-inheritance:
-
-nilmtk.node module
-------------------
-
-.. automodule:: nilmtk.node
-    :members:
-    :undoc-members:
-    :show-inheritance:
-
-nilmtk.plots module
--------------------
-
-.. automodule:: nilmtk.plots
-    :members:
-    :undoc-members:
-    :show-inheritance:
-
-nilmtk.results module
----------------------
-
-.. automodule:: nilmtk.results
-    :members:
-    :undoc-members:
-    :show-inheritance:
-
-nilmtk.timeframe module
------------------------
-
-.. automodule:: nilmtk.timeframe
-    :members:
-    :undoc-members:
-    :show-inheritance:
-
-nilmtk.timeframegroup module
-----------------------------
-
-.. automodule:: nilmtk.timeframegroup
-    :members:
-    :undoc-members:
-    :show-inheritance:
-
-nilmtk.utils module
--------------------
-
-.. automodule:: nilmtk.utils
-    :members:
-    :undoc-members:
-    :show-inheritance:
-
-nilmtk.version module
----------------------
-
-.. automodule:: nilmtk.version
-    :members:
-    :undoc-members:
-    :show-inheritance:
-
+   nilmtk.appliance
+   nilmtk.building
+   nilmtk.consts
+   nilmtk.dataset
+   nilmtk.docinherit
+   nilmtk.elecmeter
+   nilmtk.electric
+   nilmtk.exceptions
+   nilmtk.hashable
+   nilmtk.measurement
+   nilmtk.metergroup
+   nilmtk.metrics
+   nilmtk.node
+   nilmtk.plots
+   nilmtk.results
+   nilmtk.timeframe
+   nilmtk.timeframegroup
+   nilmtk.utils
+   nilmtk.version
 
 Module contents
 ---------------

--- a/docs/source/nilmtk.stats.dropoutrate.rst
+++ b/docs/source/nilmtk.stats.dropoutrate.rst
@@ -1,0 +1,65 @@
+nilmtk\.stats\.dropoutrate
+==========================
+
+.. topic:: Module summary
+
+    .. automodule:: nilmtk.stats.dropoutrate
+       :no-members:
+       :no-undoc-members:
+       :no-show-inheritance: 
+
+       .. rubric:: Functions
+
+       .. autosummary::
+
+          get_dropout_rate
+
+    
+       .. rubric:: Classes
+
+       .. autosummary::
+        
+          DropoutRate
+    
+
+
+    
+
+
+    
+        
+
+.. topic:: Class: DropoutRate
+
+    .. autoclass:: DropoutRate
+       :no-members:
+       :no-undoc-members:
+            
+       .. Note:: This class has inherited methods, see the base class(es) for additional methods
+            
+            
+       .. rubric:: Methods
+
+       .. autosummary::
+                
+            process
+            
+            
+       .. rubric:: Attributes
+
+       .. autosummary::
+                
+            postconditions
+            requirements
+            
+    
+
+
+.. rubric:: Module detail
+
+.. automodule:: nilmtk.stats.dropoutrate
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+

--- a/docs/source/nilmtk.stats.dropoutrateresults.rst
+++ b/docs/source/nilmtk.stats.dropoutrateresults.rst
@@ -1,0 +1,61 @@
+nilmtk\.stats\.dropoutrateresults
+=================================
+
+.. topic:: Module summary
+
+    .. automodule:: nilmtk.stats.dropoutrateresults
+       :no-members:
+       :no-undoc-members:
+       :no-show-inheritance: 
+
+    
+       .. rubric:: Classes
+
+       .. autosummary::
+        
+          DropoutRateResults
+    
+
+
+    
+
+
+    
+        
+
+.. topic:: Class: DropoutRateResults
+
+    .. autoclass:: DropoutRateResults
+       :no-members:
+       :no-undoc-members:
+            
+       .. Note:: This class has inherited methods, see the base class(es) for additional methods
+            
+            
+       .. rubric:: Methods
+
+       .. autosummary::
+                
+            combined
+            plot
+            to_dict
+            unify
+            
+            
+       .. rubric:: Attributes
+
+       .. autosummary::
+                
+            name
+            
+    
+
+
+.. rubric:: Module detail
+
+.. automodule:: nilmtk.stats.dropoutrateresults
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+

--- a/docs/source/nilmtk.stats.goodsections.rst
+++ b/docs/source/nilmtk.stats.goodsections.rst
@@ -1,0 +1,66 @@
+nilmtk\.stats\.goodsections
+===========================
+
+.. topic:: Module summary
+
+    .. automodule:: nilmtk.stats.goodsections
+       :no-members:
+       :no-undoc-members:
+       :no-show-inheritance: 
+
+       .. rubric:: Functions
+
+       .. autosummary::
+
+          get_good_sections
+
+    
+       .. rubric:: Classes
+
+       .. autosummary::
+        
+          GoodSections
+    
+
+
+    
+
+
+    
+        
+
+.. topic:: Class: GoodSections
+
+    .. autoclass:: GoodSections
+       :no-members:
+       :no-undoc-members:
+            
+       .. Note:: This class has inherited methods, see the base class(es) for additional methods
+            
+            
+       .. rubric:: Methods
+
+       .. autosummary::
+                
+            process
+            reset
+            
+            
+       .. rubric:: Attributes
+
+       .. autosummary::
+                
+            postconditions
+            requirements
+            
+    
+
+
+.. rubric:: Module detail
+
+.. automodule:: nilmtk.stats.goodsections
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+

--- a/docs/source/nilmtk.stats.goodsectionsresults.rst
+++ b/docs/source/nilmtk.stats.goodsectionsresults.rst
@@ -1,0 +1,64 @@
+nilmtk\.stats\.goodsectionsresults
+==================================
+
+.. topic:: Module summary
+
+    .. automodule:: nilmtk.stats.goodsectionsresults
+       :no-members:
+       :no-undoc-members:
+       :no-show-inheritance: 
+
+    
+       .. rubric:: Classes
+
+       .. autosummary::
+        
+          GoodSectionsResults
+    
+
+
+    
+
+
+    
+        
+
+.. topic:: Class: GoodSectionsResults
+
+    .. autoclass:: GoodSectionsResults
+       :no-members:
+       :no-undoc-members:
+            
+       .. Note:: This class has inherited methods, see the base class(es) for additional methods
+            
+            
+       .. rubric:: Methods
+
+       .. autosummary::
+                
+            append
+            combined
+            export_to_cache
+            import_from_cache
+            plot
+            to_dict
+            unify
+            
+            
+       .. rubric:: Attributes
+
+       .. autosummary::
+                
+            name
+            
+    
+
+
+.. rubric:: Module detail
+
+.. automodule:: nilmtk.stats.goodsectionsresults
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+

--- a/docs/source/nilmtk.stats.histogram.rst
+++ b/docs/source/nilmtk.stats.histogram.rst
@@ -1,0 +1,7 @@
+nilmtk\.stats\.histogram module
+===============================
+
+.. automodule:: nilmtk.stats.histogram
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/nilmtk.stats.rst
+++ b/docs/source/nilmtk.stats.rst
@@ -1,5 +1,5 @@
-nilmtk.stats package
-====================
+nilmtk\.stats package
+=====================
 
 Subpackages
 -----------
@@ -11,67 +11,13 @@ Subpackages
 Submodules
 ----------
 
-nilmtk.stats.dropoutrate module
--------------------------------
+.. toctree::
 
-.. automodule:: nilmtk.stats.dropoutrate
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   nilmtk.stats.dropoutrate
+   nilmtk.stats.dropoutrateresults
+   nilmtk.stats.goodsections
+   nilmtk.stats.goodsectionsresults
+   nilmtk.stats.histogram
+   nilmtk.stats.totalenergy
+   nilmtk.stats.totalenergyresults
 
-nilmtk.stats.dropoutrateresults module
---------------------------------------
-
-.. automodule:: nilmtk.stats.dropoutrateresults
-    :members:
-    :undoc-members:
-    :show-inheritance:
-
-nilmtk.stats.goodsections module
---------------------------------
-
-.. automodule:: nilmtk.stats.goodsections
-    :members:
-    :undoc-members:
-    :show-inheritance:
-
-nilmtk.stats.goodsectionsresults module
----------------------------------------
-
-.. automodule:: nilmtk.stats.goodsectionsresults
-    :members:
-    :undoc-members:
-    :show-inheritance:
-
-nilmtk.stats.histogram module
------------------------------
-
-.. automodule:: nilmtk.stats.histogram
-    :members:
-    :undoc-members:
-    :show-inheritance:
-
-nilmtk.stats.totalenergy module
--------------------------------
-
-.. automodule:: nilmtk.stats.totalenergy
-    :members:
-    :undoc-members:
-    :show-inheritance:
-
-nilmtk.stats.totalenergyresults module
---------------------------------------
-
-.. automodule:: nilmtk.stats.totalenergyresults
-    :members:
-    :undoc-members:
-    :show-inheritance:
-
-
-Module contents
----------------
-
-.. automodule:: nilmtk.stats
-    :members:
-    :undoc-members:
-    :show-inheritance:

--- a/docs/source/nilmtk.stats.tests.rst
+++ b/docs/source/nilmtk.stats.tests.rst
@@ -1,46 +1,13 @@
-nilmtk.stats.tests package
-==========================
+nilmtk\.stats\.tests package
+============================
 
 Submodules
 ----------
 
-nilmtk.stats.tests.test_dropoutrate module
-------------------------------------------
+.. toctree::
 
-.. automodule:: nilmtk.stats.tests.test_dropoutrate
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   nilmtk.stats.tests.test_dropoutrate
+   nilmtk.stats.tests.test_locategoodsections
+   nilmtk.stats.tests.test_totalenergy
+   nilmtk.stats.tests.test_totalenergyresults
 
-nilmtk.stats.tests.test_locategoodsections module
--------------------------------------------------
-
-.. automodule:: nilmtk.stats.tests.test_locategoodsections
-    :members:
-    :undoc-members:
-    :show-inheritance:
-
-nilmtk.stats.tests.test_totalenergy module
-------------------------------------------
-
-.. automodule:: nilmtk.stats.tests.test_totalenergy
-    :members:
-    :undoc-members:
-    :show-inheritance:
-
-nilmtk.stats.tests.test_totalenergyresults module
--------------------------------------------------
-
-.. automodule:: nilmtk.stats.tests.test_totalenergyresults
-    :members:
-    :undoc-members:
-    :show-inheritance:
-
-
-Module contents
----------------
-
-.. automodule:: nilmtk.stats.tests
-    :members:
-    :undoc-members:
-    :show-inheritance:

--- a/docs/source/nilmtk.stats.tests.test_dropoutrate.rst
+++ b/docs/source/nilmtk.stats.tests.test_dropoutrate.rst
@@ -1,0 +1,57 @@
+nilmtk\.stats\.tests\.test\_dropoutrate
+=======================================
+
+.. topic:: Module summary
+
+    .. automodule:: nilmtk.stats.tests.test_dropoutrate
+       :no-members:
+       :no-undoc-members:
+       :no-show-inheritance: 
+
+    
+       .. rubric:: Classes
+
+       .. autosummary::
+        
+          TestLocateGoodSections
+    
+
+
+    
+
+
+    
+        
+
+.. topic:: Class: TestLocateGoodSections
+
+    .. autoclass:: TestLocateGoodSections
+       :no-members:
+       :no-undoc-members:
+            
+            
+       .. rubric:: Methods
+
+       .. autosummary::
+                
+            test_pipeline
+            
+            
+       .. rubric:: Attributes
+
+       .. autosummary::
+                
+            longMessage
+            maxDiff
+            
+    
+
+
+.. rubric:: Module detail
+
+.. automodule:: nilmtk.stats.tests.test_dropoutrate
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+

--- a/docs/source/nilmtk.stats.tests.test_locategoodsections.rst
+++ b/docs/source/nilmtk.stats.tests.test_locategoodsections.rst
@@ -1,0 +1,58 @@
+nilmtk\.stats\.tests\.test\_locategoodsections
+==============================================
+
+.. topic:: Module summary
+
+    .. automodule:: nilmtk.stats.tests.test_locategoodsections
+       :no-members:
+       :no-undoc-members:
+       :no-show-inheritance: 
+
+    
+       .. rubric:: Classes
+
+       .. autosummary::
+        
+          TestLocateGoodSections
+    
+
+
+    
+
+
+    
+        
+
+.. topic:: Class: TestLocateGoodSections
+
+    .. autoclass:: TestLocateGoodSections
+       :no-members:
+       :no-undoc-members:
+            
+            
+       .. rubric:: Methods
+
+       .. autosummary::
+                
+            test_pipeline
+            test_process_chunk
+            
+            
+       .. rubric:: Attributes
+
+       .. autosummary::
+                
+            longMessage
+            maxDiff
+            
+    
+
+
+.. rubric:: Module detail
+
+.. automodule:: nilmtk.stats.tests.test_locategoodsections
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+

--- a/docs/source/nilmtk.stats.tests.test_totalenergy.rst
+++ b/docs/source/nilmtk.stats.tests.test_totalenergy.rst
@@ -1,0 +1,64 @@
+nilmtk\.stats\.tests\.test\_totalenergy
+=======================================
+
+.. topic:: Module summary
+
+    .. automodule:: nilmtk.stats.tests.test_totalenergy
+       :no-members:
+       :no-undoc-members:
+       :no-show-inheritance: 
+
+       .. rubric:: Functions
+
+       .. autosummary::
+
+          check_energy_numbers
+
+    
+       .. rubric:: Classes
+
+       .. autosummary::
+        
+          TestEnergy
+    
+
+
+    
+
+
+    
+        
+
+.. topic:: Class: TestEnergy
+
+    .. autoclass:: TestEnergy
+       :no-members:
+       :no-undoc-members:
+            
+            
+       .. rubric:: Methods
+
+       .. autosummary::
+                
+            test_energy_per_power_series
+            test_pipeline
+            
+            
+       .. rubric:: Attributes
+
+       .. autosummary::
+                
+            longMessage
+            maxDiff
+            
+    
+
+
+.. rubric:: Module detail
+
+.. automodule:: nilmtk.stats.tests.test_totalenergy
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+

--- a/docs/source/nilmtk.stats.tests.test_totalenergyresults.rst
+++ b/docs/source/nilmtk.stats.tests.test_totalenergyresults.rst
@@ -1,0 +1,58 @@
+nilmtk\.stats\.tests\.test\_totalenergyresults
+==============================================
+
+.. topic:: Module summary
+
+    .. automodule:: nilmtk.stats.tests.test_totalenergyresults
+       :no-members:
+       :no-undoc-members:
+       :no-show-inheritance: 
+
+    
+       .. rubric:: Classes
+
+       .. autosummary::
+        
+          TestEnergyResults
+    
+
+
+    
+
+
+    
+        
+
+.. topic:: Class: TestEnergyResults
+
+    .. autoclass:: TestEnergyResults
+       :no-members:
+       :no-undoc-members:
+            
+            
+       .. rubric:: Methods
+
+       .. autosummary::
+                
+            test_append
+            test_combined
+            
+            
+       .. rubric:: Attributes
+
+       .. autosummary::
+                
+            longMessage
+            maxDiff
+            
+    
+
+
+.. rubric:: Module detail
+
+.. automodule:: nilmtk.stats.tests.test_totalenergyresults
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+

--- a/docs/source/nilmtk.stats.totalenergy.rst
+++ b/docs/source/nilmtk.stats.totalenergy.rst
@@ -1,0 +1,66 @@
+nilmtk\.stats\.totalenergy
+==========================
+
+.. topic:: Module summary
+
+    .. automodule:: nilmtk.stats.totalenergy
+       :no-members:
+       :no-undoc-members:
+       :no-show-inheritance: 
+
+       .. rubric:: Functions
+
+       .. autosummary::
+
+          get_total_energy
+
+    
+       .. rubric:: Classes
+
+       .. autosummary::
+        
+          TotalEnergy
+    
+
+
+    
+
+
+    
+        
+
+.. topic:: Class: TotalEnergy
+
+    .. autoclass:: TotalEnergy
+       :no-members:
+       :no-undoc-members:
+            
+       .. Note:: This class has inherited methods, see the base class(es) for additional methods
+            
+            
+       .. rubric:: Methods
+
+       .. autosummary::
+                
+            process
+            required_measurements
+            
+            
+       .. rubric:: Attributes
+
+       .. autosummary::
+                
+            postconditions
+            requirements
+            
+    
+
+
+.. rubric:: Module detail
+
+.. automodule:: nilmtk.stats.totalenergy
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+

--- a/docs/source/nilmtk.stats.totalenergyresults.rst
+++ b/docs/source/nilmtk.stats.totalenergyresults.rst
@@ -1,0 +1,62 @@
+nilmtk\.stats\.totalenergyresults
+=================================
+
+.. topic:: Module summary
+
+    .. automodule:: nilmtk.stats.totalenergyresults
+       :no-members:
+       :no-undoc-members:
+       :no-show-inheritance: 
+
+    
+       .. rubric:: Classes
+
+       .. autosummary::
+        
+          TotalEnergyResults
+    
+
+
+    
+
+
+    
+        
+
+.. topic:: Class: TotalEnergyResults
+
+    .. autoclass:: TotalEnergyResults
+       :no-members:
+       :no-undoc-members:
+            
+       .. Note:: This class has inherited methods, see the base class(es) for additional methods
+            
+            
+       .. rubric:: Methods
+
+       .. autosummary::
+                
+            append
+            export_to_cache
+            simple
+            to_dict
+            unify
+            
+            
+       .. rubric:: Attributes
+
+       .. autosummary::
+                
+            name
+            
+    
+
+
+.. rubric:: Module detail
+
+.. automodule:: nilmtk.stats.totalenergyresults
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+

--- a/docs/source/nilmtk.tests.generate_data.rst
+++ b/docs/source/nilmtk.tests.generate_data.rst
@@ -1,0 +1,40 @@
+nilmtk\.tests\.generate\_data
+=============================
+
+.. topic:: Module summary
+
+    .. automodule:: nilmtk.tests.generate_data
+       :no-members:
+       :no-undoc-members:
+       :no-show-inheritance: 
+
+       .. rubric:: Functions
+
+       .. autosummary::
+
+          add_building_metadata
+          create_all
+          create_co_test_hdf5
+          create_energy_hdf5
+          create_random_df
+          create_random_df_hierarchical_column_index
+          create_random_hdf5
+          power_data
+
+    
+
+
+    
+
+
+    
+
+
+.. rubric:: Module detail
+
+.. automodule:: nilmtk.tests.generate_data
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+

--- a/docs/source/nilmtk.tests.rst
+++ b/docs/source/nilmtk.tests.rst
@@ -1,102 +1,21 @@
-nilmtk.tests package
-====================
+nilmtk\.tests package
+=====================
 
 Submodules
 ----------
 
-nilmtk.tests.generate_data module
----------------------------------
+.. toctree::
 
-.. automodule:: nilmtk.tests.generate_data
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   nilmtk.tests.generate_data
+   nilmtk.tests.test_combinatorial_optimisation
+   nilmtk.tests.test_datastore
+   nilmtk.tests.test_datastore_converter
+   nilmtk.tests.test_elecmeter
+   nilmtk.tests.test_fhmm
+   nilmtk.tests.test_measurement
+   nilmtk.tests.test_metergroup
+   nilmtk.tests.test_metrics
+   nilmtk.tests.test_node
+   nilmtk.tests.test_timeframe
+   nilmtk.tests.testingtools
 
-nilmtk.tests.test_combinatorial_optimisation module
----------------------------------------------------
-
-.. automodule:: nilmtk.tests.test_combinatorial_optimisation
-    :members:
-    :undoc-members:
-    :show-inheritance:
-
-nilmtk.tests.test_datastore module
-----------------------------------
-
-.. automodule:: nilmtk.tests.test_datastore
-    :members:
-    :undoc-members:
-    :show-inheritance:
-
-nilmtk.tests.test_datastore_converter module
---------------------------------------------
-
-.. automodule:: nilmtk.tests.test_datastore_converter
-    :members:
-    :undoc-members:
-    :show-inheritance:
-
-nilmtk.tests.test_elecmeter module
-----------------------------------
-
-.. automodule:: nilmtk.tests.test_elecmeter
-    :members:
-    :undoc-members:
-    :show-inheritance:
-
-nilmtk.tests.test_measurement module
-------------------------------------
-
-.. automodule:: nilmtk.tests.test_measurement
-    :members:
-    :undoc-members:
-    :show-inheritance:
-
-nilmtk.tests.test_metergroup module
------------------------------------
-
-.. automodule:: nilmtk.tests.test_metergroup
-    :members:
-    :undoc-members:
-    :show-inheritance:
-
-nilmtk.tests.test_metrics module
---------------------------------
-
-.. automodule:: nilmtk.tests.test_metrics
-    :members:
-    :undoc-members:
-    :show-inheritance:
-
-nilmtk.tests.test_node module
------------------------------
-
-.. automodule:: nilmtk.tests.test_node
-    :members:
-    :undoc-members:
-    :show-inheritance:
-
-nilmtk.tests.test_timeframe module
-----------------------------------
-
-.. automodule:: nilmtk.tests.test_timeframe
-    :members:
-    :undoc-members:
-    :show-inheritance:
-
-nilmtk.tests.testingtools module
---------------------------------
-
-.. automodule:: nilmtk.tests.testingtools
-    :members:
-    :undoc-members:
-    :show-inheritance:
-
-
-Module contents
----------------
-
-.. automodule:: nilmtk.tests
-    :members:
-    :undoc-members:
-    :show-inheritance:

--- a/docs/source/nilmtk.tests.test_combinatorial_optimisation.rst
+++ b/docs/source/nilmtk.tests.test_combinatorial_optimisation.rst
@@ -1,0 +1,57 @@
+nilmtk\.tests\.test\_combinatorial\_optimisation
+================================================
+
+.. topic:: Module summary
+
+    .. automodule:: nilmtk.tests.test_combinatorial_optimisation
+       :no-members:
+       :no-undoc-members:
+       :no-show-inheritance: 
+
+    
+       .. rubric:: Classes
+
+       .. autosummary::
+        
+          TestCO
+    
+
+
+    
+
+
+    
+        
+
+.. topic:: Class: TestCO
+
+    .. autoclass:: TestCO
+       :no-members:
+       :no-undoc-members:
+            
+            
+       .. rubric:: Methods
+
+       .. autosummary::
+                
+            test_co_correctness
+            
+            
+       .. rubric:: Attributes
+
+       .. autosummary::
+                
+            longMessage
+            maxDiff
+            
+    
+
+
+.. rubric:: Module detail
+
+.. automodule:: nilmtk.tests.test_combinatorial_optimisation
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+

--- a/docs/source/nilmtk.tests.test_datastore.rst
+++ b/docs/source/nilmtk.tests.test_datastore.rst
@@ -1,0 +1,116 @@
+nilmtk\.tests\.test\_datastore
+==============================
+
+.. topic:: Module summary
+
+    .. automodule:: nilmtk.tests.test_datastore
+       :no-members:
+       :no-undoc-members:
+       :no-show-inheritance: 
+
+    
+       .. rubric:: Classes
+
+       .. autosummary::
+        
+          SuperTestDataStore
+          TestCSVDataStore
+          TestHDFDataStore
+    
+
+
+    
+
+
+    
+        
+
+.. topic:: Class: SuperTestDataStore
+
+    .. autoclass:: SuperTestDataStore
+       :no-members:
+       :no-undoc-members:
+            
+            
+       .. rubric:: Methods
+
+       .. autosummary::
+                
+            test_load
+            test_load_chunks
+            test_load_chunks_small_chunksize
+            test_timeframe
+            
+            
+       .. rubric:: Attributes
+
+       .. autosummary::
+                
+            END_DATE
+            NROWS
+            START_DATE
+            TIMEFRAME
+            
+
+.. topic:: Class: TestCSVDataStore
+
+    .. autoclass:: TestCSVDataStore
+       :no-members:
+       :no-undoc-members:
+            
+       .. Note:: This class has inherited methods, see the base class(es) for additional methods
+            
+            
+            
+       .. rubric:: Attributes
+
+       .. autosummary::
+                
+            END_DATE
+            NROWS
+            START_DATE
+            TIMEFRAME
+            longMessage
+            maxDiff
+            
+
+.. topic:: Class: TestHDFDataStore
+
+    .. autoclass:: TestHDFDataStore
+       :no-members:
+       :no-undoc-members:
+            
+       .. Note:: This class has inherited methods, see the base class(es) for additional methods
+            
+            
+       .. rubric:: Methods
+
+       .. autosummary::
+                
+            test_column_names
+            test_estimate_memory_requirement
+            test_n_rows
+            
+            
+       .. rubric:: Attributes
+
+       .. autosummary::
+                
+            END_DATE
+            NROWS
+            START_DATE
+            TIMEFRAME
+            longMessage
+            maxDiff
+            
+    
+
+
+.. rubric:: Module detail
+
+.. automodule:: nilmtk.tests.test_datastore
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+

--- a/docs/source/nilmtk.tests.test_datastore_converter.rst
+++ b/docs/source/nilmtk.tests.test_datastore_converter.rst
@@ -1,0 +1,7 @@
+nilmtk\.tests\.test\_datastore\_converter module
+================================================
+
+.. automodule:: nilmtk.tests.test_datastore_converter
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/nilmtk.tests.test_elecmeter.rst
+++ b/docs/source/nilmtk.tests.test_elecmeter.rst
@@ -1,0 +1,63 @@
+nilmtk\.tests\.test\_elecmeter
+==============================
+
+.. topic:: Module summary
+
+    .. automodule:: nilmtk.tests.test_elecmeter
+       :no-members:
+       :no-undoc-members:
+       :no-show-inheritance: 
+
+    
+       .. rubric:: Classes
+
+       .. autosummary::
+        
+          TestElecMeter
+    
+
+
+    
+
+
+    
+        
+
+.. topic:: Class: TestElecMeter
+
+    .. autoclass:: TestElecMeter
+       :no-members:
+       :no-undoc-members:
+            
+       .. Note:: This class has inherited methods, see the base class(es) for additional methods
+            
+            
+       .. rubric:: Methods
+
+       .. autosummary::
+                
+            correlation
+            test_load
+            test_proportion_of_energy
+            test_total_energy
+            test_upstream_meter
+            
+            
+       .. rubric:: Attributes
+
+       .. autosummary::
+                
+            longMessage
+            maxDiff
+            
+    
+
+
+.. rubric:: Module detail
+
+.. automodule:: nilmtk.tests.test_elecmeter
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+

--- a/docs/source/nilmtk.tests.test_fhmm.rst
+++ b/docs/source/nilmtk.tests.test_fhmm.rst
@@ -1,0 +1,57 @@
+nilmtk\.tests\.test\_fhmm
+=========================
+
+.. topic:: Module summary
+
+    .. automodule:: nilmtk.tests.test_fhmm
+       :no-members:
+       :no-undoc-members:
+       :no-show-inheritance: 
+
+    
+       .. rubric:: Classes
+
+       .. autosummary::
+        
+          TestFHMM
+    
+
+
+    
+
+
+    
+        
+
+.. topic:: Class: TestFHMM
+
+    .. autoclass:: TestFHMM
+       :no-members:
+       :no-undoc-members:
+            
+            
+       .. rubric:: Methods
+
+       .. autosummary::
+                
+            test_fhmm_correctness
+            
+            
+       .. rubric:: Attributes
+
+       .. autosummary::
+                
+            longMessage
+            maxDiff
+            
+    
+
+
+.. rubric:: Module detail
+
+.. automodule:: nilmtk.tests.test_fhmm
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+

--- a/docs/source/nilmtk.tests.test_measurement.rst
+++ b/docs/source/nilmtk.tests.test_measurement.rst
@@ -1,0 +1,59 @@
+nilmtk\.tests\.test\_measurement
+================================
+
+.. topic:: Module summary
+
+    .. automodule:: nilmtk.tests.test_measurement
+       :no-members:
+       :no-undoc-members:
+       :no-show-inheritance: 
+
+    
+       .. rubric:: Classes
+
+       .. autosummary::
+        
+          TestMeasurement
+    
+
+
+    
+
+
+    
+        
+
+.. topic:: Class: TestMeasurement
+
+    .. autoclass:: TestMeasurement
+       :no-members:
+       :no-undoc-members:
+            
+            
+       .. rubric:: Methods
+
+       .. autosummary::
+                
+            test_as_dataframe_columns
+            test_check_ac_type
+            test_select_best_ac_type
+            
+            
+       .. rubric:: Attributes
+
+       .. autosummary::
+                
+            longMessage
+            maxDiff
+            
+    
+
+
+.. rubric:: Module detail
+
+.. automodule:: nilmtk.tests.test_measurement
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+

--- a/docs/source/nilmtk.tests.test_metergroup.rst
+++ b/docs/source/nilmtk.tests.test_metergroup.rst
@@ -1,0 +1,65 @@
+nilmtk\.tests\.test\_metergroup
+===============================
+
+.. topic:: Module summary
+
+    .. automodule:: nilmtk.tests.test_metergroup
+       :no-members:
+       :no-undoc-members:
+       :no-show-inheritance: 
+
+    
+       .. rubric:: Classes
+
+       .. autosummary::
+        
+          TestMeterGroup
+    
+
+
+    
+
+
+    
+        
+
+.. topic:: Class: TestMeterGroup
+
+    .. autoclass:: TestMeterGroup
+       :no-members:
+       :no-undoc-members:
+            
+            
+       .. rubric:: Methods
+
+       .. autosummary::
+                
+            test_dual_supply
+            test_from_list
+            test_full_results_with_no_sections_raises_runtime_error
+            test_getitem
+            test_load
+            test_proportion_of_energy_submetered
+            test_select
+            test_total_energy
+            test_wiring_graph
+            
+            
+       .. rubric:: Attributes
+
+       .. autosummary::
+                
+            longMessage
+            maxDiff
+            
+    
+
+
+.. rubric:: Module detail
+
+.. automodule:: nilmtk.tests.test_metergroup
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+

--- a/docs/source/nilmtk.tests.test_metrics.rst
+++ b/docs/source/nilmtk.tests.test_metrics.rst
@@ -1,0 +1,57 @@
+nilmtk\.tests\.test\_metrics
+============================
+
+.. topic:: Module summary
+
+    .. automodule:: nilmtk.tests.test_metrics
+       :no-members:
+       :no-undoc-members:
+       :no-show-inheritance: 
+
+    
+       .. rubric:: Classes
+
+       .. autosummary::
+        
+          TestMetrics
+    
+
+
+    
+
+
+    
+        
+
+.. topic:: Class: TestMetrics
+
+    .. autoclass:: TestMetrics
+       :no-members:
+       :no-undoc-members:
+            
+            
+       .. rubric:: Methods
+
+       .. autosummary::
+                
+            test_f1
+            
+            
+       .. rubric:: Attributes
+
+       .. autosummary::
+                
+            longMessage
+            maxDiff
+            
+    
+
+
+.. rubric:: Module detail
+
+.. automodule:: nilmtk.tests.test_metrics
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+

--- a/docs/source/nilmtk.tests.test_node.rst
+++ b/docs/source/nilmtk.tests.test_node.rst
@@ -1,0 +1,57 @@
+nilmtk\.tests\.test\_node
+=========================
+
+.. topic:: Module summary
+
+    .. automodule:: nilmtk.tests.test_node
+       :no-members:
+       :no-undoc-members:
+       :no-show-inheritance: 
+
+    
+       .. rubric:: Classes
+
+       .. autosummary::
+        
+          TestNode
+    
+
+
+    
+
+
+    
+        
+
+.. topic:: Class: TestNode
+
+    .. autoclass:: TestNode
+       :no-members:
+       :no-undoc-members:
+            
+            
+       .. rubric:: Methods
+
+       .. autosummary::
+                
+            test_unsatisfied_requirements
+            
+            
+       .. rubric:: Attributes
+
+       .. autosummary::
+                
+            longMessage
+            maxDiff
+            
+    
+
+
+.. rubric:: Module detail
+
+.. automodule:: nilmtk.tests.test_node
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+

--- a/docs/source/nilmtk.tests.test_timeframe.rst
+++ b/docs/source/nilmtk.tests.test_timeframe.rst
@@ -1,0 +1,62 @@
+nilmtk\.tests\.test\_timeframe
+==============================
+
+.. topic:: Module summary
+
+    .. automodule:: nilmtk.tests.test_timeframe
+       :no-members:
+       :no-undoc-members:
+       :no-show-inheritance: 
+
+    
+       .. rubric:: Classes
+
+       .. autosummary::
+        
+          TestTimeFrame
+    
+
+
+    
+
+
+    
+        
+
+.. topic:: Class: TestTimeFrame
+
+    .. autoclass:: TestTimeFrame
+       :no-members:
+       :no-undoc-members:
+            
+            
+       .. rubric:: Methods
+
+       .. autosummary::
+                
+            test_adjacent
+            test_date_setting
+            test_intersection
+            test_merge_timeframes
+            test_time_delta
+            test_union
+            
+            
+       .. rubric:: Attributes
+
+       .. autosummary::
+                
+            longMessage
+            maxDiff
+            
+    
+
+
+.. rubric:: Module detail
+
+.. automodule:: nilmtk.tests.test_timeframe
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+

--- a/docs/source/nilmtk.tests.testingtools.rst
+++ b/docs/source/nilmtk.tests.testingtools.rst
@@ -1,0 +1,7 @@
+nilmtk\.tests\.testingtools module
+==================================
+
+.. automodule:: nilmtk.tests.testingtools
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/nilmtk.timeframe.rst
+++ b/docs/source/nilmtk.timeframe.rst
@@ -1,0 +1,81 @@
+nilmtk\.timeframe
+=================
+
+.. topic:: Module summary
+
+    .. automodule:: nilmtk.timeframe
+       :no-members:
+       :no-undoc-members:
+       :no-show-inheritance: 
+
+       .. rubric:: Functions
+
+       .. autosummary::
+
+          convert_nat_to_none
+          convert_none_to_nat
+          list_of_timeframe_dicts
+          list_of_timeframes_from_list_of_dicts
+          merge_timeframes
+          split_timeframes
+          timeframe_from_dict
+
+    
+       .. rubric:: Classes
+
+       .. autosummary::
+        
+          TimeFrame
+    
+
+
+    
+
+
+    
+        
+
+.. topic:: Class: TimeFrame
+
+    .. autoclass:: TimeFrame
+       :no-members:
+       :no-undoc-members:
+            
+            
+       .. rubric:: Methods
+
+       .. autosummary::
+                
+            adjacent
+            check_for_overlap
+            check_tz
+            clear
+            copy_constructor
+            intersection
+            query_terms
+            slice
+            split
+            to_dict
+            union
+            
+            
+       .. rubric:: Attributes
+
+       .. autosummary::
+                
+            empty
+            end
+            start
+            timedelta
+            
+    
+
+
+.. rubric:: Module detail
+
+.. automodule:: nilmtk.timeframe
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+

--- a/docs/source/nilmtk.timeframegroup.rst
+++ b/docs/source/nilmtk.timeframegroup.rst
@@ -1,0 +1,53 @@
+nilmtk\.timeframegroup
+======================
+
+.. topic:: Module summary
+
+    .. automodule:: nilmtk.timeframegroup
+       :no-members:
+       :no-undoc-members:
+       :no-show-inheritance: 
+
+    
+       .. rubric:: Classes
+
+       .. autosummary::
+        
+          TimeFrameGroup
+    
+
+
+    
+
+
+    
+        
+
+.. topic:: Class: TimeFrameGroup
+
+    .. autoclass:: TimeFrameGroup
+       :no-members:
+       :no-undoc-members:
+            
+            
+       .. rubric:: Methods
+
+       .. autosummary::
+                
+            intersection
+            plot
+            remove_shorter_than
+            uptime
+            
+            
+    
+
+
+.. rubric:: Module detail
+
+.. automodule:: nilmtk.timeframegroup
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+

--- a/docs/source/nilmtk.utils.rst
+++ b/docs/source/nilmtk.utils.rst
@@ -1,0 +1,61 @@
+nilmtk\.utils
+=============
+
+.. topic:: Module summary
+
+    .. automodule:: nilmtk.utils
+       :no-members:
+       :no-undoc-members:
+       :no-show-inheritance: 
+
+       .. rubric:: Functions
+
+       .. autosummary::
+
+          append_or_extend_list
+          capitalise_first_letter
+          capitalise_index
+          capitalise_legend
+          check_directory_exists
+          container_to_string
+          convert_to_list
+          convert_to_timestamp
+          dict_to_html
+          find_nearest
+          flatten_2d_list
+          get_datastore
+          get_index
+          get_module_directory
+          get_tz
+          index_of_column_name
+          most_common
+          nodes_adjacent_to_root
+          normalise_timestamp
+          offset_alias_to_seconds
+          print_dict
+          print_on_line
+          safe_resample
+          show_versions
+          simplest_type_for
+          timedelta64_to_secs
+          timestamp_is_naive
+          tree_root
+          tz_localize_naive
+
+    
+
+
+    
+
+
+    
+
+
+.. rubric:: Module detail
+
+.. automodule:: nilmtk.utils
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+

--- a/docs/source/nilmtk.version.rst
+++ b/docs/source/nilmtk.version.rst
@@ -1,0 +1,7 @@
+nilmtk\.version module
+======================
+
+.. automodule:: nilmtk.version
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/nilmtk/dataset_converters/greend/metadata/dataset.yaml
+++ b/nilmtk/dataset_converters/greend/metadata/dataset.yaml
@@ -1,11 +1,11 @@
-name: GREEND
+﻿name: GREEND
 long_name: GREEND Electrical ENergy Dataset
 creators:
 - Egarter, Dominik
 - Elmenreich, Wilfried
 - Monacchi, Andrea
 - Pöchacker, Manfred
-timezone: Europe/Vienna
+timezone: CET
 #date: 
 #contact:
 institution: Alpen-Adria-Universität

--- a/nilmtk/dataset_converters/refit/convert_refit.py
+++ b/nilmtk/dataset_converters/refit/convert_refit.py
@@ -15,7 +15,7 @@ from nilmtk.utils import get_module_directory, check_directory_exists
 from nilm_metadata import convert_yaml_to_hdf5, save_yaml_to_datastore
 
 
-def convert_refit(input_path, output_filename, format='HDF'):
+def convert_refit(input_path, output_filename, format='HDF',verbose=True):
     """
     Parameters
     ----------
@@ -25,14 +25,18 @@ def convert_refit(input_path, output_filename, format='HDF'):
         The destination filename (including path and suffix).
     format : str
         format of output. Either 'HDF' or 'CSV'. Defaults to 'HDF'
+    verbose: boolean
+        Ture for more detailed diagnostic output and help
     """
         
     # Open DataStore
     store = get_datastore(output_filename, format, mode='w')
 
     # Convert raw data to DataStore
-    _convert(input_path, store, 'Europe/London')
-
+    _convert(input_path, store, 'Europe/London',verbose)
+# MEN
+    if verbose:
+        print ('Note this converter uses a localisation of Europe/London which must be consistent with the timezone variable in the dataset.yaml file' )
     # Add metadata
     save_yaml_to_datastore(join(get_module_directory(), 
                               'dataset_converters', 
@@ -43,7 +47,7 @@ def convert_refit(input_path, output_filename, format='HDF'):
 
     print("Done converting REFIT to HDF5!")
 
-def _convert(input_path, store, tz, sort_index=True):
+def _convert(input_path, store, tz, verbose,sort_index=True):
     """
     Parameters
     ----------
@@ -60,9 +64,13 @@ def _convert(input_path, store, tz, sort_index=True):
         Timezone e.g. 'US/Eastern'
     sort_index : bool
     """
-
+    if verbose:
+        print ('Files names begin with: CLEAN_House')  
+        print
     check_directory_exists(input_path)
-
+    columns = ['Timestamp_datetime','Timestamp','Aggregate','Appliance1','Appliance2','Appliance3','Appliance4','Appliance5','Appliance6','Appliance7','Appliance8','Appliance9','Issues']
+    if verbose:
+        print ('\n Expected column names: \n' + str(columns) + '\n')
     # Iterate though all houses and channels
     # house 14 is missing!
     houses = [1,2,3,4,5,6,7,8,9,10,11,12,13,15,16,17,18,19,20,21]
@@ -70,10 +78,10 @@ def _convert(input_path, store, tz, sort_index=True):
     for house_id in houses:
         nilmtk_house_id += 1
         print("Loading house", house_id, end="... ")
+        csv_filename = input_path + 'CLEAN_House' + str(house_id) + '.csv'
+        df = _load_csv(csv_filename, columns, tz,verbose)
+        print ('Meter:',end=' ')
         stdout.flush()
-        csv_filename = input_path + 'House' + str(house_id) + '.csv'
-        columns = ['Timestamp','Aggregate','Appliance1','Appliance2','Appliance3','Appliance4','Appliance5','Appliance6','Appliance7','Appliance8','Appliance9']
-        df = _load_csv(csv_filename, columns, tz)
         if sort_index:
             df = df.sort_index() # might not be sorted...
         chan_id = 0
@@ -84,6 +92,9 @@ def _convert(input_path, store, tz, sort_index=True):
             key = Key(building=nilmtk_house_id, meter=chan_id)
             
             chan_df = pd.DataFrame(df[col])
+            df_nulls = ((len(chan_df) - chan_df.count()[0])*1.0)/(len(chan_df) *1.0)
+            if verbose and df_nulls>0:
+                print ('%% null values in column ' + col + ' %0.3f' % (df_nulls*100))
             chan_df.columns = pd.MultiIndex.from_tuples([('power', 'active')])
             
             # Modify the column labels to reflect the power measurements recorded.
@@ -92,7 +103,7 @@ def _convert(input_path, store, tz, sort_index=True):
             store.put(str(key), chan_df)
         print('')
 
-def _load_csv(filename, columns, tz):
+def _load_csv(filename, columns, tz,verbose):
     """
     Parameters
     ----------
@@ -105,8 +116,12 @@ def _load_csv(filename, columns, tz):
     dataframe
     """
     # Load data
-    df = pd.read_csv(filename, names=columns)
-    
+    df = pd.read_csv(filename, names=columns,skiprows=1)
+    df_issues = (df.Issues.sum()*1.0)/(len(df)*1.0)
+    if verbose and df_issues>0:
+        print ('Records with issues dropped: %0.3f%%' % (df_issues*100))
+    df = df[df.Issues ==0]
+    df = df.drop(['Timestamp_datetime','Issues'],axis=1)
     # Convert the integer index column to timezone-aware datetime 
     df['Timestamp'] = pd.to_datetime(df.Timestamp, unit='s', utc=True)
     df.set_index('Timestamp', inplace=True)


### PR DESCRIPTION
Clean data has been published by the University of Strathclyde.  The existing converter needs to be modified for the new file format.

This does not have duplicate indices, but includes additional columns and a header row.

- file prefix has changed to Clean_House
- header row is included
- A datetime and unix datatime is included.
- An issues column to identify rows where the power of meters exceeds the limit for the meter =1, 0 otherwise

Issues are now dropped by the converter and the proportion dropped is reported as a proportion of the overall file.

Nan values are also checked for and reported, but not removed.

A couple of helpers to identify the prefix as well as the localisation datetime format.