### PR TITLE
Workaround for #647

### DIFF
--- a/nilmtk/disaggregate/fhmm_exact.py
+++ b/nilmtk/disaggregate/fhmm_exact.py
@@ -269,6 +269,11 @@ class FHMM(Disaggregator):
             power_series = meter.power_series(**load_kwargs)
             meter_data = next(power_series).dropna()
             X = meter_data.values.reshape((-1, 1))
+            
+            if not len(X):
+                print("Submeter '{}' has no samples, skipping...".format(meter))
+                continue
+                
             assert X.ndim == 2
             self.X = X
 

--- a/nilmtk/elecmeter.py
+++ b/nilmtk/elecmeter.py
@@ -727,7 +727,10 @@ class ElecMeter(Hashable, Electric):
                 except:
                     return res
                 else:
-                    return pd.Series(res[ac_types], index=ac_types)
+                    if res.empty:
+                        return res
+                    else:
+                        return pd.Series(res[ac_types], index=ac_types)
             else:
                 return res
 

--- a/nilmtk/metergroup.py
+++ b/nilmtk/metergroup.py
@@ -1318,11 +1318,19 @@ class MeterGroup(Electric):
         function_map = {'energy': self.fraction_per_meter, 'entropy': self.entropy_per_meter}
         top_k_series = function_map[by](**kwargs)
         top_k_series.sort_values(inplace=True, ascending=asc)
-        top_k_elec_meter_ids = top_k_series[:k].index
+        top_k_elec_meter_ids = list(top_k_series[:k].index)
+        
+        #TODO: investigate the root cause for missing namedtuple type, remove this workaround
+        if top_k_elec_meter_ids and type(top_k_elec_meter_ids[0]) is tuple and len(top_k_elec_meter_ids[0]) == 3:
+            top_k_elec_meter_ids = [ElecMeterID(*key) for key in top_k_elec_meter_ids]
+        
         top_k_metergroup = self.from_list(top_k_elec_meter_ids)
 
         if group_remainder:
-            remainder_ids = top_k_series[k:].index
+            remainder_ids = list(top_k_series[k:].index)
+            if remainder_ids and type(remainder_ids[0]) is tuple and len(remainder_ids[0]) == 3:
+                remainder_ids = [ElecMeterID(*key) for key in remainder_ids]
+            
             remainder_metergroup = self.from_list(remainder_ids)
             remainder_metergroup.name = 'others'
             top_k_metergroup.meters.append(remainder_metergroup)


### PR DESCRIPTION
`MeterGroup.select_top_k()`: Convert plain tuple keys to `ElecMeterID` instances if their sizes match. This is a workaround and should be reverted when the root cause of the issue is found.
