### PR TITLE
Update hart_85.py: "rb" option when opening pickle file

### DIFF
--- a/nilmtk/disaggregate/hart_85.py
+++ b/nilmtk/disaggregate/hart_85.py
@@ -528,7 +528,7 @@ class Hart85(Disaggregator):
         pickle_out.close()
 
     def import_model(self, filename):
-        pickle_in = open(filename)
+        pickle_in = open(filename, "rb")
         self.model = pickle.load(pickle_in)
         self.columns = self.model['columns']
         self.state_threshold = self.model['state_threshold']


### PR DESCRIPTION
Using the `"rb"` options allows the file to be read without hitting the `utf-8` error. Using the demo notebook for hart_85 and uncommenting the import/export model code will show the error. This PR is to fix that issue.