### PR TITLE
Clean up code (PEP8 and unused imports) to dataset_converters and tests

### DIFF
--- a/nilmtk/dataset_converters/ampds/convert_ampds.py
+++ b/nilmtk/dataset_converters/ampds/convert_ampds.py
@@ -2,13 +2,13 @@ from __future__ import print_function, division
 import numpy as np
 import pandas as pd
 from os.path import *
-from os import getcwd
 from os import listdir
+
 from nilmtk.datastore import Key
 from nilmtk.measurement import LEVEL_NAMES
-from nilmtk.utils import check_directory_exists, get_datastore, get_module_directory
+from nilmtk.utils import \
+    check_directory_exists, get_datastore, get_module_directory
 from nilm_metadata import convert_yaml_to_hdf5
-from sys import getfilesystemencoding
 
 # Column name mapping
 columnNameMapping = {'V': ('voltage', ''),
@@ -26,12 +26,14 @@ columnNameMapping = {'V': ('voltage', ''),
 TIMESTAMP_COLUMN_NAME = "TS"
 TIMEZONE = "America/Vancouver"
 
+
 def convert_ampds(input_path, output_filename, format='HDF'):
     """
     Convert AMPds R2013 as seen on Dataverse. Download the files
     as CSVs and put them in the `input_path` folder for conversion.
     
-    Download URL: https://dataverse.harvard.edu/dataset.xhtml?persistentId=doi:10.7910/DVN/MXB7VO
+    Download URL: https://
+    dataverse.harvard.edu/dataset.xhtml?persistentId=doi:10.7910/DVN/MXB7VO
     
     Parameters: 
     -----------
@@ -81,6 +83,7 @@ def convert_ampds(input_path, output_filename, format='HDF'):
         print("Done with file #", (i + 1))
         
     store.close()
-    metadata_path = join(get_module_directory(), 'dataset_converters', 'ampds', 'metadata')
+    metadata_path = join(get_module_directory(),
+                         'dataset_converters', 'ampds', 'metadata')
     print('Processing metadata...')
     convert_yaml_to_hdf5(metadata_path, output_filename)

--- a/nilmtk/dataset_converters/combed/convert_combed.py
+++ b/nilmtk/dataset_converters/combed/convert_combed.py
@@ -1,31 +1,34 @@
 from __future__ import print_function, division
-from os.path import join, isdir, dirname, abspath
-from os import getcwd
+from os.path import join
 import os
-from sys import getfilesystemencoding
 from collections import OrderedDict
 from six import iteritems
 import pandas as pd
+
 from nilm_metadata import convert_yaml_to_hdf5
 from nilmtk.datastore import Key
 from nilmtk.measurement import LEVEL_NAMES
-from nilmtk.utils import check_directory_exists, get_datastore, get_module_directory
+from nilmtk.utils import \
+    check_directory_exists, get_datastore, get_module_directory
 
-#{"load_type": {"floor/wing":meter_number_in_nilmtk}
-acad_block_meter_mapping = {'Building Total Mains': {'0': 1},
-                            'Lifts': {'0': 2},
-                            'Floor Total': {'1': 3, '2': 4, '3': 5, '4': 6, '5': 7},
-                            'AHU': {'0': 8, '1': 9, '2': 10, '5': 11},
-                            'Light': {'3': 12},
-                            'Power Sockets': {'3': 13},
-                            'UPS Sockets': {'3': 14}}
+# {"load_type": {"floor/wing":meter_number_in_nilmtk}
+acad_block_meter_mapping = {
+    'Building Total Mains': {'0': 1},
+    'Lifts': {'0': 2},
+    'Floor Total': {'1': 3, '2': 4, '3': 5, '4': 6, '5': 7},
+    'AHU': {'0': 8, '1': 9, '2': 10, '5': 11},
+    'Light': {'3': 12},
+    'Power Sockets': {'3': 13},
+    'UPS Sockets': {'3': 14}
+}
 
 lecture_block_meter_mapping = {'Building Total Mains': {'0': 1},
                                'Floor Total': {'0': 2, '1': 3, '2': 4},
                                'AHU': {'1': 5, '2': 6, '3': 7}}
 
-overall_dataset_mapping = OrderedDict({'Academic Block': acad_block_meter_mapping,
-                                       'Lecture Block': lecture_block_meter_mapping})
+overall_dataset_mapping = OrderedDict({
+    'Academic Block': acad_block_meter_mapping,
+    'Lecture Block': lecture_block_meter_mapping})
 
 building_number_mapping = {'Academic Block': 1, 'Lecture Block': 2}
 
@@ -60,16 +63,21 @@ def convert_combed(combed_path, output_filename, format='HDF'):
                 key = Key(building=building_number, meter=meter_number)
                 dfs = []
                 for attribute in column_mapping.keys():
-                    filename_attribute = join(combed_path, building_name, load_name, load_mapping_path, "%s.csv" %attribute)
+                    filename_attribute = join(
+                        combed_path, building_name, load_name,
+                        load_mapping_path, "%s.csv" %attribute)
                     if not os.path.isfile(filename_attribute):
                         # File not found directly in the combed_path provided
                         # Try adding 'iiitd' to it
-                        filename_attribute = join(combed_path, 'iiitd', building_name, load_name, load_mapping_path, "%s.csv" %attribute)
+                        filename_attribute = join(
+                            combed_path, 'iiitd', building_name, load_name,
+                            load_mapping_path, "%s.csv" %attribute)
                     
                     if os.path.isfile(filename_attribute):
                         exists = True
                         print(filename_attribute)
-                        df = pd.read_csv(filename_attribute, names=["timestamp", attribute])
+                        df = pd.read_csv(
+                            filename_attribute, names=["timestamp", attribute])
                         df.index = pd.to_datetime(df["timestamp"], unit='ms')
                         df = df.drop("timestamp", 1)
                         dfs.append(df)
@@ -79,17 +87,20 @@ def convert_combed(combed_path, output_filename, format='HDF'):
                 if exists:
                     total = pd.concat(dfs, axis=1)
                     total = total.tz_localize('UTC').tz_convert('Asia/Kolkata')
-                    total.columns = pd.MultiIndex.from_tuples([column_mapping[x] for x in total.columns])
+                    total.columns = pd.MultiIndex.from_tuples(
+                        [column_mapping[x] for x in total.columns])
                     total.columns.set_names(LEVEL_NAMES, inplace=True)
                     assert total.index.is_unique
                     store.put(str(key), total)
                     any_file_converted = True
                     
     if not any_file_converted:
-        raise RuntimeError('No files converted, did you specify the correct path?')
+        raise RuntimeError(
+            'No files converted, did you specify the correct path?')
                     
     convert_yaml_to_hdf5(
-        join(get_module_directory(), 'dataset_converters', 'combed', 'metadata'),
+        join(get_module_directory(),
+             'dataset_converters', 'combed', 'metadata'),
         output_filename
     )
 

--- a/nilmtk/dataset_converters/dataport/download_dataport.py
+++ b/nilmtk/dataset_converters/dataport/download_dataport.py
@@ -3,11 +3,11 @@ import os
 import re
 import datetime
 import sys
-from os.path import join, isdir, isfile, dirname, abspath
+from os.path import join
 import pandas as pd
 import yaml
+
 import psycopg2 as db
-from nilmtk.measurement import measurement_columns
 from nilmtk.measurement import LEVEL_NAMES
 from nilmtk.datastore import Key
 from nilm_metadata import convert_yaml_to_hdf5

--- a/nilmtk/dataset_converters/eco/convert_eco.py
+++ b/nilmtk/dataset_converters/eco/convert_eco.py
@@ -1,40 +1,41 @@
-from __future__ import print_function
-import pandas as pd
-import numpy as np
-import sys
-from os import listdir, getcwd
-from os.path import isdir, join, dirname, abspath
-from pandas import concat
-from nilmtk.utils import get_module_directory, check_directory_exists
-from nilmtk.datastore import Key
-from nilmtk.measurement import LEVEL_NAMES
-from nilm_metadata import convert_yaml_to_hdf5
-
 """
 DATASET STRUCTURE:
 ------------------
-On extracting all the dataset values, we should arrive at a similar directory structure as
-mentioned.
+On extracting all the dataset values, we should arrive at a similar
+directory structure as mentioned.
 
-ECO Dataset will have a folder '<i>_sm_csv' and '<i>_plug_csv' where i is the building no.
+ECO Dataset will have a folder '<i>_sm_csv' and '<i>_plug_csv' where i is the
+building no.
 Originally, the expected folder structure was:
 
 - <i>_sm_csv has a folder <i>
 - <i>_plug_csv has folders 01, 02,....<n> where n is the plug numbers.
 
-This version also supports the following structure, which can be created by unpacking the 
-ZIP files uniformly, creating a folder for each one:
+This version also supports the following structure, which can be created by
+unpacking the ZIP files uniformly, creating a folder for each one:
 
 - <i>_sm_csv has a folder <i>
-- <i>_plug_csv has a folder <i>, and <i>_plug_csv/<i> has folders 01, 02,....<n>,
+- <i>_plug_csv has a folder <i>, and <i>_plug_csv/<i> has folders 01, 02,...<n>,
   where n is the plug numbers.
 
 
 Each folder has a CSV file as per each day, with each day csv file containing
-	86400 entries.
+86400 entries.
 """
 
+from __future__ import print_function
+import pandas as pd
+import numpy as np
+from os import listdir
+from os.path import isdir, join
+
+from nilmtk.utils import get_module_directory, check_directory_exists
+from nilmtk.datastore import Key
+from nilmtk.measurement import LEVEL_NAMES
+from nilm_metadata import convert_yaml_to_hdf5
+
 plugs_column_name = {1: ('power', 'active')}
+
 
 def convert_eco(dataset_loc, hdf_filename, timezone):
     """
@@ -67,7 +68,7 @@ def convert_eco(dataset_loc, hdf_filename, timezone):
             print('Skipping ', folder)
             continue
 
-        #Building number and meter_flag
+        # Building number and meter_flag
         building_no = int(folder[:2])
         meter_flag = None 
         if 'sm_csv' in folder:
@@ -76,48 +77,55 @@ def convert_eco(dataset_loc, hdf_filename, timezone):
             meter_flag = 'plugs'
         else:
             print('Skipping folder', folder)
-            continue
-            
+
         print('Computing for folder', folder)
 
-        dir_list = [i for i in listdir(join(dataset_loc, folder)) if isdir(join(dataset_loc,folder,i))]
+        dir_list = [i for i in listdir(join(dataset_loc, folder))
+                    if isdir(join(dataset_loc, folder, i))]
         dir_list.sort()
         
         if meter_flag == 'plugs' and len(dir_list) < 3:
             # Try harder to find the subfolders
             folder = join(folder, folder[:2])
-            dir_list = [i for i in listdir(join(dataset_loc, folder)) if isdir(join(dataset_loc,folder,i))]
+            dir_list = [i for i in listdir(join(dataset_loc, folder))
+                        if isdir(join(dataset_loc, folder, i))]
         
         print('Current dir list:', dir_list)
 
         for fl in dir_list:
             print('Computing for folder ', fl)
             
-            fl_dir_list = [i for i in listdir(join(dataset_loc,folder,fl)) if '.csv' in i]
+            fl_dir_list = [i for i in listdir(join(dataset_loc, folder, fl))
+                           if '.csv' in i]
             fl_dir_list.sort()
 
             if meter_flag == 'sm':
                 for fi in fl_dir_list:
                     found_any_sm = True
-                    df = pd.read_csv(join(dataset_loc,folder,fl,fi), names=[i for i in range(1,17)], dtype=np.float32)
+                    df = pd.read_csv(
+                        join(dataset_loc, folder, fl, fi),
+                        names=[i for i in range(1, 17)], dtype=np.float32)
                     
-                    for phase in range(1,4):
+                    for phase in range(1, 4):
                         key = str(Key(building=building_no, meter=phase))
-                        df_phase = df.loc[:,[1+phase, 5+phase, 8+phase, 13+phase]]
+                        df_phase = \
+                            df.loc[:, [1+phase, 5+phase, 8+phase, 13+phase]]
 
                         # get reactive power
                         power = df_phase.loc[:, (1+phase, 13+phase)].values
-                        reactive = power[:,0] * np.tan(power[:,1] * np.pi / 180)
+                        reactive = \
+                            power[:, 0] * np.tan(power[:, 1] * np.pi / 180)
                         df_phase['Q'] = reactive
                         
-                        df_phase.index = pd.date_range(start=fi[:-4], freq='s', periods=86400, tz='GMT')
+                        df_phase.index = pd.date_range(
+                            start=fi[:-4], freq='s', periods=86400, tz='GMT')
                         df_phase = df_phase.tz_convert(timezone)
                         
                         sm_column_name = {
-                            1+phase:('power', 'active'),
-                            5+phase:('current', ''),
-                            8+phase:('voltage', ''),
-                            13+phase:('phase_angle', ''),
+                            1+phase: ('power', 'active'),
+                            5+phase: ('current', ''),
+                            8+phase: ('voltage', ''),
+                            13+phase: ('phase_angle', ''),
                             'Q': ('power', 'reactive'),
                         }
                         df_phase.columns = pd.MultiIndex.from_tuples([
@@ -131,67 +139,74 @@ def convert_eco(dataset_loc, hdf_filename, timezone):
                         tmp_after = np.size(power_active)
                         
                         if tmp_before != tmp_after:
-                            print('Removed missing measurements - Size before: ' + str(tmp_before) + ', size after: ' + str(tmp_after))
+                            print('Removed missing measurements - '
+                                  'Size before: ' + str(tmp_before) +
+                                  ', size after: ' + str(tmp_after))
                         
                         df_phase.columns.set_names(LEVEL_NAMES, inplace=True)
-                        if not key in store:
+                        if key not in store:
                             store.put(key, df_phase, format='Table')
                         else:
                             store.append(key, df_phase, format='Table')
                             store.flush()
+
                         print('Building', building_no, ', Meter no.', phase,
                               '=> Done for ', fi[:-4])
                 
             else:
-                #Meter number to be used in key
+                # Meter number to be used in key
                 meter_num = int(fl) + 3
                 
                 key = str(Key(building=building_no, meter=meter_num))
 
-                current_folder = join(dataset_loc,folder,fl)
+                current_folder = join(dataset_loc, folder, fl)
                 if not fl_dir_list:
                     raise RuntimeError("No CSV file found in " + current_folder)
-                    
-                #Getting dataframe for each csv file seperately
+
+                # Getting dataframe for each csv file seperately
                 for fi in fl_dir_list:
                     found_any_plug = True
-                    df = pd.read_csv(join(current_folder, fi), names=[1], dtype=np.float64)
-                    df.index = pd.date_range(start=fi[:-4].replace('.', ':'), freq='s', periods=86400, tz='GMT')
-                    df.columns = pd.MultiIndex.from_tuples(plugs_column_name.values())
+                    df = pd.read_csv(join(current_folder, fi),
+                                     names=[1], dtype=np.float64)
+                    df.index = pd.date_range(start=fi[:-4].replace('.', ':'),
+                                             freq='s', periods=86400, tz='GMT')
+                    df.columns = pd.MultiIndex.from_tuples(
+                        plugs_column_name.values())
                     df = df.tz_convert(timezone)
                     df.columns.set_names(LEVEL_NAMES, inplace=True)
 
                     tmp_before = np.size(df.power.active)
                     df = df[df.power.active != -1]
                     tmp_after = np.size(df.power.active)
-                    if (tmp_before != tmp_after):
-                        print('Removed missing measurements - Size before: ' + str(tmp_before) + ', size after: ' + str(tmp_after))
+                    if tmp_before != tmp_after:
+                        print('Removed missing measurements - Size before: ' +
+                              str(tmp_before) + ', size after: ' +
+                              str(tmp_after))
                     
-                    # If table not present in hdf5, create or else append to existing data
-                    if not key in store:
+                    # If table not present in hdf5, create or else append to
+                    # existing data
+                    if key not in store:
                         store.put(key, df, format='Table')
-                        print('Building',building_no,', Meter no.',meter_num,'=> Done for ',fi[:-4])
+                        print('Building', building_no, ', Meter no.',
+                              meter_num, '=> Done for ', fi[:-4])
                     else:
                         store.append(key, df, format='Table')
                         store.flush()
-                        print('Building',building_no,', Meter no.',meter_num,'=> Done for ',fi[:-4])
-            
-            
+                        print('Building', building_no, ', Meter no.',
+                              meter_num, '=> Done for ', fi[:-4])
+
     if not found_any_plug or not found_any_sm:
-        raise RuntimeError('The files were not found! Please check the folder structure. Extract each ZIP file into a folder with its base name (e.g. extract "01_plugs_csv.zip" into a folder named "01_plugs_csv", etc.)')
+        raise RuntimeError('The files were not found! Please check the folder '
+                           'structure. Extract each ZIP file into a folder '
+                           'with its base name (e.g. extract "01_plugs_csv.zip"'
+                           ' into a folder named "01_plugs_csv", etc.)')
         
     print("Data storage completed.")
     store.close()
 
     # Adding the metadata to the HDF5file
     print("Proceeding to Metadata conversion...")
-    meta_path = join(
-        get_module_directory(), 
-        'dataset_converters',
-        'eco',
-        'metadata'
-    )
+    meta_path = join(get_module_directory(),
+                     'dataset_converters', 'eco', 'metadata')
     convert_yaml_to_hdf5(meta_path, hdf_filename)
     print("Completed Metadata conversion.")
-
-

--- a/nilmtk/dataset_converters/hes/convert_hes.py
+++ b/nilmtk/dataset_converters/hes/convert_hes.py
@@ -1,37 +1,28 @@
-from __future__ import print_function, division
-from os.path import join
-import pandas as pd
-import numpy as np
-from nilmtk.utils import get_module_directory
-from nilmtk import DataSet
-from nilmtk.utils import get_datastore
-from nilmtk.datastore import Key
-from nilmtk.measurement import LEVEL_NAMES
-from nilm_metadata import convert_yaml_to_hdf5
-import tempfile, shutil
-from sys import stderr
-import yaml
 """
 TODO
 ----
 * convert HES appliance names to NILMTK standard
 * what exactly is measured? Real power? Apparent?
-* houses which have multiple mains: are they multiple 'splits' or phases or meters?
+* houses which have multiple mains: are they multiple 'splits' or phases or
+  meters?
 * dataset metadata
-* some houses have both 2- and 10-minute data.  Might need a function to ignore 10 minute data.
-* set up wiring to take into consideration the information in 
+* some houses have both 2- and 10-minute data.  Might need a function to ignore
+  10 minute data.
+* set up wiring to take into consideration the information in
   'total_profiles.csv'  Sockets 1-11 are circuits monitored
   at the consumer unit which feed fall sockets around the dwelling.
-* import the enormous amount of appliance metadata in 'appliance_data.csv', 
+* import the enormous amount of appliance metadata in 'appliance_data.csv',
   especially channels which recorded multiple appliances
-* use the metadata in 'ipsos.csv' and 'rdsap_data.csv' and 'rdsap_*.csv' for each Building
+* use the metadata in 'ipsos.csv' and 'rdsap_data.csv' and 'rdsap_*.csv' for
+  each Building
 * Maybe email CAR to let them know that nilmtk can now import HES.
 HES notes
 ---------
 * As of 2018, the dataset is available from ukdataservice.ac.uk
 * 14 homes recorded mains but only 5 were kept after cleaning
-* circuit-level data from the consumer unit was recorded as 'sockets' for 216 houses
-* 'total_profiles.csv' records pairs of <house>,<appliance> which are the 
+* circuit-level data from the consumer unit was recorded as 'sockets' for 216
+  houses
+* 'total_profiles.csv' records pairs of <house>,<appliance> which are the
   channels which need to be added to produce the whole-home total, which
   I think consists of all the circuit-level meters plus all appliances
   which are not also monitored at circuit level.
@@ -39,31 +30,46 @@ HES notes
 * appliance 159 represents the difference between ???
   this and the sum of the known appliances
 * appliance_codes.csv maps from <appliance code> to <appliance name>
-* seasonal_adjustments.csv stores the trends in energy usage per appliance 
+* seasonal_adjustments.csv stores the trends in energy usage per appliance
   activation over a year.
 """
 
+from __future__ import print_function, division
+from os.path import join
+import pandas as pd
+import numpy as np
+import tempfile, shutil
+from sys import stderr
+import yaml
+
+from nilmtk.utils import get_module_directory
+from nilmtk.utils import get_datastore
+from nilmtk.datastore import Key
+from nilmtk.measurement import LEVEL_NAMES
+from nilm_metadata import convert_yaml_to_hdf5
+
+
 FILENAMES = ['agd-{s}/appliance_group_data-{s}.csv'.format(s=s) for s in
-             ['1a','1b','1c','1d','2','3']]
-CHUNKSIZE = 1E6 # number of rows
-COL_NAMES = ['interval id', 'house id', 'appliance code', 'date', 'data', 'time']
+             ['1a', '1b', '1c', '1d', '2', '3']]
+CHUNKSIZE = 1E6  # number of rows
+COL_NAMES = ['interval id', 'house id', 'appliance code',
+             'date', 'data', 'time']
 LAST_PWR_COLUMN = 250
 NANOSECONDS_PER_TENTH_OF_AN_HOUR = 1E9 * 60 * 6
 MAINS_CODES = [240, 241]
 TEMPERATURE_CODES = list(range(251, 256))
 CIRCUIT_CODES = list(range(208, 218)) + [222]
-#E_MEASUREMENT = Measurement('energy', 'active')
+# E_MEASUREMENT = Measurement('energy', 'active')
 
 def load_list_of_house_ids(data_dir):
     """Returns a list of house IDs in HES (ints)."""
-    filename = join(data_dir, 'anonhes', 'ipsos-anonymised-corrected_310713.csv')
+    filename = join(data_dir,
+                    'anonhes', 'ipsos-anonymised-corrected_310713.csv')
     series = pd.read_csv(filename, usecols=[0], index_col=False, squeeze=True)
     return series.tolist()
 
-
     """Load data from UK Government's Household Electricity Survey 
-    (the cleaned version of the dataset released in summer 2013).
-    """
+    (the cleaned version of the dataset released in summer 2013)."""
 
     # TODO: re-use code from 
     # https://github.com/JackKelly/pda/blob/master/scripts/hes/load_hes.py
@@ -90,10 +96,11 @@ def load_list_of_house_ids(data_dir):
         * convert keys of `dataset.buildings`
     """
 
+
 def convert_hes(data_dir, output_filename, format='HDF', max_chunks=None):
     metadata = {
         'name': 'HES',
-        'geographic_coordinates': (51.464462,-0.076544), # London
+        'geographic_coordinates': (51.464462, -0.076544),  # London
         'timezone': 'Europe/London'
     }
     
@@ -101,24 +108,25 @@ def convert_hes(data_dir, output_filename, format='HDF', max_chunks=None):
     store = get_datastore(output_filename, format, mode='w')
     
     # load list of appliances
-    hes_to_nilmtk_appliance_lookup = pd.read_csv(join(get_module_directory(), 
-                                        'dataset_converters', 
-                                        'hes', 
-                                        'hes_to_nilmtk_appliance_lookup.csv'))
+    hes_to_nilmtk_appliance_lookup = pd.read_csv(
+        join(get_module_directory(),
+             'dataset_converters', 'hes', 'hes_to_nilmtk_appliance_lookup.csv'))
 
     # load list of houses
     hes_house_ids = load_list_of_house_ids(data_dir)
     nilmtk_house_ids = np.arange(1, len(hes_house_ids) + 1)
     hes_to_nilmtk_house_ids = dict(zip(hes_house_ids, nilmtk_house_ids))
 
-    # array of hes_house_codes: nilmtk_building_code = house_codes.index(hes_house_code)
+    # array of hes_house_codes: nilmtk_building_code =
+    # house_codes.index(hes_house_code)
     house_codes = []
     
     # map 
     house_appliance_codes = dict()
 
     # Create a temporary metadata dir
-    original_metadata_dir = join(get_module_directory(), 'dataset_converters', 'hes', 'metadata')
+    original_metadata_dir = join(get_module_directory(),
+                                 'dataset_converters', 'hes', 'metadata')
     tmp_dir = tempfile.mkdtemp()
     metadata_dir = join(tmp_dir, 'metadata')
     shutil.copytree(original_metadata_dir, metadata_dir)
@@ -147,7 +155,8 @@ def convert_hes(data_dir, output_filename, format='HDF', max_chunks=None):
             dt = chunk['date'] + ' ' + chunk['time']
             del chunk['date']
             del chunk['time']
-            chunk['datetime'] = pd.to_datetime(dt, format='%Y-%m-%d %H:%M:%S', utc=True)
+            chunk['datetime'] = pd.to_datetime(
+                dt, format='%Y-%m-%d %H:%M:%S', utc=True)
 
             # Data is either tenths of a Wh or tenths of a degree
             chunk['data'] *= 10
@@ -167,12 +176,13 @@ def convert_hes(data_dir, output_filename, format='HDF', max_chunks=None):
                 for appliance_code, appliance_df in chunk.groupby('appliance code'):
                     if appliance_code not in house_appliance_codes[hes_house_id]:
                         house_appliance_codes[hes_house_id].append(appliance_code)
-                    nilmtk_meter_id = house_appliance_codes[hes_house_id].index(appliance_code)+1
-                    _process_meter_in_chunk(nilmtk_house_id, nilmtk_meter_id, hes_house_id_df, store, appliance_code)
+                    nilmtk_meter_id = house_appliance_codes[hes_house_id].index(appliance_code) + 1
+                    _process_meter_in_chunk(
+                        nilmtk_house_id, nilmtk_meter_id, hes_house_id_df,
+                        store, appliance_code)
                     
             chunk_i += 1
-            
-            
+
     print('houses with some data loaded:', house_appliance_codes.keys())
     
     store.close()
@@ -190,7 +200,8 @@ def convert_hes(data_dir, output_filename, format='HDF', max_chunks=None):
         instance_counter = {}
         
         for appliance_code in house_appliance_codes[hes_house_id]:
-            nilmtk_meter_id = house_appliance_codes[hes_house_id].index(appliance_code)+1
+            nilmtk_meter_id = \
+                house_appliance_codes[hes_house_id].index(appliance_code) + 1
             # meter metadata
             if appliance_code in MAINS_CODES:
                 meter_metadata = {'device_model': 'multivoies',
@@ -201,36 +212,37 @@ def convert_hes(data_dir, output_filename, format='HDF', max_chunks=None):
                 break
             elif appliance_code in TEMPERATURE_CODES:
                 break
-            else: # is appliance
+            else:  # is appliance
                 meter_metadata = {'device_model': 'wattmeter'}
                 
             # only appliance meters at this point
             building_metadata['elec_meters'][nilmtk_meter_id] = meter_metadata
             # appliance metadata
-            lookup_row = hes_to_nilmtk_appliance_lookup[hes_to_nilmtk_appliance_lookup.Code==appliance_code].iloc[0]
+            lookup_row = hes_to_nilmtk_appliance_lookup[
+                hes_to_nilmtk_appliance_lookup.Code == appliance_code].iloc[0]
             appliance_metadata = {'original_name': lookup_row.Name, 
                                       'meters': [nilmtk_meter_id] }
             # appliance type
             appliance_metadata.update({'type': lookup_row.nilmtk_name})
             # TODO appliance room
-            
+
             # appliance instance number
-            if instance_counter.get(lookup_row.nilmtk_name) == None:
+            if instance_counter.get(lookup_row.nilmtk_name) is None:
                 instance_counter[lookup_row.nilmtk_name] = 0
             instance_counter[lookup_row.nilmtk_name] += 1 
-            appliance_metadata['instance'] = instance_counter[lookup_row.nilmtk_name]
-            
+            appliance_metadata['instance'] = \
+                instance_counter[lookup_row.nilmtk_name]
+
             building_metadata['appliances'].append(appliance_metadata)
-            
-            
+
         building = 'building{:d}'.format(nilmtk_building_id)
-        
+
         yaml_full_filename = join(
             metadata_dir, building + '.yaml'
         )
 
         with open(yaml_full_filename, 'w') as outfile:
-            #print(building_metadata)
+            # print(building_metadata)
             outfile.write(yaml.dump(building_metadata))
             
     # write yaml metadata to hdf5
@@ -243,7 +255,8 @@ def convert_hes(data_dir, output_filename, format='HDF', max_chunks=None):
     shutil.rmtree(tmp_dir)
     
 
-def _process_meter_in_chunk(nilmtk_house_id, meter_id, chunk, store, appliance_code):
+def _process_meter_in_chunk(nilmtk_house_id, meter_id, chunk, store,
+                            appliance_code):
     data = chunk['data'].values
     index = chunk['datetime']
     df = pd.DataFrame(data=data, index=index)

--- a/nilmtk/dataset_converters/iawe/convert_iawe.py
+++ b/nilmtk/dataset_converters/iawe/convert_iawe.py
@@ -2,11 +2,14 @@ from __future__ import print_function, division
 import pandas as pd
 import numpy as np
 from os.path import join
+from copy import deepcopy
+
 from nilmtk.datastore import Key
 from nilmtk.measurement import LEVEL_NAMES
-from nilmtk.utils import check_directory_exists, get_datastore, get_module_directory
+from nilmtk.utils import \
+    check_directory_exists, get_datastore, get_module_directory
 from nilm_metadata import convert_yaml_to_hdf5
-from copy import deepcopy
+
 
 def reindex_fill_na(df, idx):
     df_copy = deepcopy(df)
@@ -57,6 +60,8 @@ def convert_iawe(iawe_path, output_filename, format="HDF"):
         The root path of the iawe dataset.
     output_filename : str
         The destination filename (including path and suffix).
+    format : str
+        Format of output. Either 'HDF' or 'CSV'. Defaults to 'HDF'
     """
 
     check_directory_exists(iawe_path)
@@ -91,8 +96,8 @@ def convert_iawe(iawe_path, output_filename, format="HDF"):
         store.put(str(key), df)
     store.close()
     
-    metadata_dir = join(get_module_directory(), 'dataset_converters', 'iawe', 'metadata')
+    metadata_dir = join(get_module_directory(),
+                        'dataset_converters', 'iawe', 'metadata')
     convert_yaml_to_hdf5(metadata_dir, output_filename)
 
     print("Done converting iAWE to HDF5!")
-

--- a/nilmtk/dataset_converters/redd/convert_redd.py
+++ b/nilmtk/dataset_converters/redd/convert_redd.py
@@ -1,17 +1,16 @@
 from __future__ import print_function, division
 import pandas as pd
 import numpy as np
-from copy import deepcopy
 from os.path import join, isdir, isfile
 from os import listdir
 import re
 from sys import stdout
+
 from nilmtk.utils import get_datastore
 from nilmtk.datastore import Key
-from nilmtk.timeframe import TimeFrame
 from nilmtk.measurement import LEVEL_NAMES
 from nilmtk.utils import get_module_directory, check_directory_exists
-from nilm_metadata import convert_yaml_to_hdf5, save_yaml_to_datastore
+from nilm_metadata import save_yaml_to_datastore
 
 """
 TODO:
@@ -43,18 +42,12 @@ def convert_redd(redd_path, output_filename, format='HDF'):
     # Convert raw data to DataStore
     _convert(redd_path, store, _redd_measurement_mapping_func, 'US/Eastern')
 
-    s=join(get_module_directory(),
-                              'dataset_converters',
-                              'redd',
-                              'metadata')
-
+    yaml_dir = join(get_module_directory(),
+             'dataset_converters', 'redd', 'metadata')
 
     # Add metadata
-    save_yaml_to_datastore(join(get_module_directory(), 
-                              'dataset_converters', 
-                              'redd', 
-                              'metadata'),
-                         store)
+    save_yaml_to_datastore(yaml_dir=yaml_dir, store=store)
+
     store.close()
 
     print("Done converting REDD to HDF5!")

--- a/nilmtk/dataset_converters/ukdale/convert_ukdale.py
+++ b/nilmtk/dataset_converters/ukdale/convert_ukdale.py
@@ -2,6 +2,7 @@ from __future__ import print_function, division
 from os import remove
 from os.path import join
 from six import iteritems
+
 from nilmtk.dataset_converters.redd.convert_redd import (_convert, _load_csv)
 from nilmtk import DataSet
 from nilmtk.utils import get_datastore
@@ -13,7 +14,8 @@ ONE_SEC_COLUMNS = [('power', 'active'), ('power', 'apparent'), ('voltage', '')]
 TZ = 'Europe/London'
 
 
-def convert_ukdale(ukdale_path, output_filename, format='HDF', drop_duplicates=True):
+def convert_ukdale(
+        ukdale_path, output_filename, format='HDF', drop_duplicates=True):
     """Converts the UK-DALE dataset to NILMTK HDF5 format.
 
     For more information about the UK-DALE dataset, and to download
@@ -102,7 +104,8 @@ def _convert_one_sec_data(ukdale_path, store, ac_type_map, drop_duplicates):
         print("Loading 1-second data for", key, "...")
         house_path = 'house_{:d}'.format(key.building)
         filename = join(ukdale_path, house_path, 'mains.dat')
-        df = _load_csv(filename, ONE_SEC_COLUMNS, TZ, drop_duplicates=drop_duplicates)
+        df = _load_csv(filename, ONE_SEC_COLUMNS, TZ,
+                       drop_duplicates=drop_duplicates)
         store.put(str(key), df)
 
     store.close()

--- a/nilmtk/tests/generate_data.py
+++ b/nilmtk/tests/generate_data.py
@@ -1,11 +1,11 @@
 from __future__ import print_function, division
 import pandas as pd
 from datetime import timedelta
-from nilmtk.tests.testingtools import data_dir
 from os.path import join
-import itertools
 from collections import OrderedDict
 import numpy as np
+
+from nilmtk.tests.testingtools import data_dir
 from nilmtk.consts import JOULES_PER_KWH
 from nilmtk.measurement import measurement_columns, AC_TYPES
 from nilmtk.utils import flatten_2d_list
@@ -80,6 +80,7 @@ def create_random_df_hierarchical_column_index():
                              size=(N_PERIODS,
                                    N_METERS * N_MEASUREMENTS_PER_METER))
     return pd.DataFrame(data=data, index=rng, columns=columns, dtype=np.float32)
+
 
 MEASUREMENTS = [('power', 'active'), ('energy', 'reactive'), ('voltage', '')]
 

--- a/nilmtk/tests/test_combinatorial_optimisation.py
+++ b/nilmtk/tests/test_combinatorial_optimisation.py
@@ -1,11 +1,11 @@
 #!/usr/bin/python
+
 from __future__ import print_function, division
 import unittest
 from os.path import join
-from os import remove
 import pandas as pd
+
 from .testingtools import data_dir
-from nilmtk.datastore import HDFDataStore
 from nilmtk import DataSet
 from nilmtk.disaggregate import CombinatorialOptimisation
 

--- a/nilmtk/tests/test_datastore.py
+++ b/nilmtk/tests/test_datastore.py
@@ -1,12 +1,15 @@
 #!/usr/bin/python
+
 from __future__ import print_function, division
+
 import unittest
 from os.path import join
 import pandas as pd
 from datetime import timedelta
-from .testingtools import data_dir
-from nilmtk.datastore import HDFDataStore, CSVDataStore
+
 from nilmtk import TimeFrame
+from nilmtk.datastore import HDFDataStore, CSVDataStore
+from nilmtk.tests.testingtools import data_dir
 
 
 # class name can't begin with test
@@ -26,7 +29,8 @@ class SuperTestDataStore(object):
             self.datastore.window.enabled = False
             self.assertEqual(self.datastore.get_timeframe(key), self.TIMEFRAME)
             self.datastore.window.enabled = True
-            self.assertEqual(self.datastore.get_timeframe(key), self.datastore.window)
+            self.assertEqual(self.datastore.get_timeframe(key),
+                             self.datastore.window)
 
     def test_load(self):
         timeframe = TimeFrame('2012-01-01 00:00:00', '2012-01-01 00:00:05')
@@ -38,7 +42,9 @@ class SuperTestDataStore(object):
         df = next(gen)
         self.assertEqual(df.index[0], timeframe.start)
         self.assertEqual(df.index[-1], timeframe.end - timedelta(seconds=1))
-#        self.assertEqual(df.look_ahead.index[0], timeframe.end) # This test, for some odd reason, fails for CSVDataStore in Python3, intermittently.  Very odd.
+        # This test, for some odd reason, fails for CSVDataStore in Python3,
+        # intermittently. Very odd.
+        # self.assertEqual(df.look_ahead.index[0], timeframe.end)
         self.assertEqual(len(df.look_ahead), 10)
 
     def test_load_chunks(self):
@@ -58,20 +64,24 @@ class SuperTestDataStore(object):
         i = 0
         for chunk in chunks:
             self.assertEqual(chunk.index[0], timeframes[i].start)
-            self.assertEqual(chunk.index[-1], timeframes[i].end-timedelta(seconds=1))
+            self.assertEqual(chunk.index[-1],
+                             timeframes[i].end - timedelta(seconds=1))
             self.assertEqual(len(chunk), 5)
             i += 1
         self.assertEqual(i, 2)
 
         # Check when we have a narrow mask
-        self.datastore.window = TimeFrame('2012-01-01 00:10:02', '2012-01-01 00:10:10')
+        self.datastore.window = \
+            TimeFrame('2012-01-01 00:10:02', '2012-01-01 00:10:10')
         chunks = self.datastore.load(key=self.keys[0], sections=timeframes)
         i = 0
         for chunk in chunks:
             if chunk.empty:
                 continue
-            self.assertEqual(chunk.index[0], pd.Timestamp('2012-01-01 00:10:02'))
-            self.assertEqual(chunk.index[-1], pd.Timestamp('2012-01-01 00:10:04'))
+            self.assertEqual(chunk.index[0],
+                             pd.Timestamp('2012-01-01 00:10:02'))
+            self.assertEqual(chunk.index[-1],
+                             pd.Timestamp('2012-01-01 00:10:04'))
             self.assertEqual(len(chunk), 3)
             i += 1
         self.assertEqual(i, 1)
@@ -90,11 +100,12 @@ class SuperTestDataStore(object):
                             chunk.index[-1] <= 
                             chunk.timeframe.end)        
 
-    #--------- helper functions ---------------------#
+    # --------- helper functions --------- #
 
     def _apply_mask(self):
-        self.datastore.window = TimeFrame('2012-01-01 00:10:00',
-                                        '2012-01-01 00:20:00')
+        self.datastore.window = \
+            TimeFrame('2012-01-01 00:10:00', '2012-01-01 00:20:00')
+
 
 class TestHDFDataStore(unittest.TestCase, SuperTestDataStore):
 
@@ -126,11 +137,14 @@ class TestHDFDataStore(unittest.TestCase, SuperTestDataStore):
         self._apply_mask()
         for key in self.keys:
             self.datastore.window.enabled = True
-            mem = self.datastore._estimate_memory_requirement(key, self.datastore._nrows(key))
+            mem = self.datastore._estimate_memory_requirement(
+                key, self.datastore._nrows(key))
             self.assertEqual(mem, 12000)
             self.datastore.window.enabled = False
-            mem = self.datastore._estimate_memory_requirement(key, self.datastore._nrows(key))
+            mem = self.datastore._estimate_memory_requirement(
+                key, self.datastore._nrows(key))
             self.assertEqual(mem, 200000)
+
 
 class TestCSVDataStore(unittest.TestCase, SuperTestDataStore):
 
@@ -143,6 +157,7 @@ class TestCSVDataStore(unittest.TestCase, SuperTestDataStore):
     @classmethod
     def tearDownClass(cls):
         cls.datastore.close()
-    
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/nilmtk/tests/test_datastore_converter.py
+++ b/nilmtk/tests/test_datastore_converter.py
@@ -1,7 +1,9 @@
-from nilmtk.datastore import HDFDataStore, CSVDataStore 
-from nilmtk.datastore.datastore import convert_datastore
 import os
 import shutil
+
+from nilmtk.datastore import HDFDataStore, CSVDataStore
+from nilmtk.datastore.datastore import convert_datastore
+
 
 def test_convert_random_dataset():
     input_filepath = 'data/random.h5'
@@ -10,11 +12,10 @@ def test_convert_random_dataset():
     if os.path.isdir(output_filepath):
         shutil.rmtree(output_filepath)
 
-    input_store=HDFDataStore(input_filepath)
-    output_store=CSVDataStore(output_filepath)
+    input_store = HDFDataStore(input_filepath)
+    output_store = CSVDataStore(output_filepath)
 
     convert_datastore(input_store, output_store)
 
     input_store.close()
     output_store.close()
-    

--- a/nilmtk/tests/test_elecmeter.py
+++ b/nilmtk/tests/test_elecmeter.py
@@ -1,17 +1,20 @@
 #!/usr/bin/python
+
 from __future__ import print_function, division
+
 import unittest
 from os.path import join
 import pandas as pd
-from datetime import timedelta
-from .testingtools import data_dir, WarningTestMixin
-from ..datastore import HDFDataStore
-from ..elecmeter import ElecMeter, ElecMeterID
-from ..stats.tests.test_totalenergy import check_energy_numbers
+
+from nilmtk.tests.testingtools import data_dir, WarningTestMixin
+from nilmtk.datastore import HDFDataStore
+from nilmtk.elecmeter import ElecMeter, ElecMeterID
+from nilmtk.stats.tests.test_totalenergy import check_energy_numbers
 
 METER_ID = ElecMeterID(instance=1, building=1, dataset='REDD')
 METER_ID2 = ElecMeterID(instance=2, building=1, dataset='REDD')
 METER_ID3 = ElecMeterID(instance=3, building=1, dataset='REDD')
+
 
 class TestElecMeter(WarningTestMixin, unittest.TestCase):
 
@@ -20,7 +23,8 @@ class TestElecMeter(WarningTestMixin, unittest.TestCase):
         filename = join(data_dir(), 'energy.h5')
         cls.datastore = HDFDataStore(filename)
         ElecMeter.load_meter_devices(cls.datastore)
-        cls.meter_meta = cls.datastore.load_metadata('building1')['elec_meters'][METER_ID.instance]
+        cls.meter_meta = cls.datastore.load_metadata(
+            'building1')['elec_meters'][METER_ID.instance]
 
     @classmethod
     def tearDownClass(cls):
@@ -66,10 +70,10 @@ class TestElecMeter(WarningTestMixin, unittest.TestCase):
         self.assertEquals(meter.proportion_of_energy(meter), 1.0)
 
     def correlation(self):
-        meter_1 = ElecMeter(store=self.datastore, metadata=self.meter_meta, 
-                          meter_id=METER_ID)
-        meter_2 = ElecMeter(store=self.datastore, metadata=self.meter_meta, 
-                          meter_id=METER_ID2)
+        meter_1 = ElecMeter(store=self.datastore, metadata=self.meter_meta,
+                            meter_id=METER_ID)
+        meter_2 = ElecMeter(store=self.datastore, metadata=self.meter_meta,
+                            meter_id=METER_ID2)
 
         # Let us get raw DataFrames 
         df1 = self.datastore.store.get('/building1/elec/meter1')
@@ -85,8 +89,8 @@ class TestElecMeter(WarningTestMixin, unittest.TestCase):
         from pandas.util.testing import assert_frame_equal
         assert_frame_equal(corr12_nilmtk, corr12_pandas)
 
-        #self.assertEqual(corr12_nilmtk, corr12_pandas)
-        #print("Correlation using pandas:", corr12_pandas)
+        # self.assertEqual(corr12_nilmtk, corr12_pandas)
+        # print("Correlation using pandas:", corr12_pandas)
 
 
 if __name__ == '__main__':

--- a/nilmtk/tests/test_fhmm.py
+++ b/nilmtk/tests/test_fhmm.py
@@ -1,12 +1,15 @@
 #!/usr/bin/python
+
 from __future__ import print_function, division
+
 import unittest
 from os.path import join
 from os import remove
-from .testingtools import data_dir
-from nilmtk.datastore import HDFDataStore
+
 from nilmtk import DataSet
+from nilmtk.datastore import HDFDataStore
 from nilmtk.disaggregate import FHMM
+from nilmtk.tests.testingtools import data_dir
 
 
 class TestFHMM(unittest.TestCase):

--- a/nilmtk/tests/test_measurement.py
+++ b/nilmtk/tests/test_measurement.py
@@ -1,14 +1,18 @@
 #!/usr/bin/python
+
 from __future__ import print_function, division
+
 import unittest
 import pandas as pd
 import numpy as np
+
 import nilmtk.measurement as measure
 from nilmtk.elecmeter import ElecMeter, ElecMeterID
 from nilmtk.exceptions import MeasurementError
 
-BAD_AC_TYPES = ['foo', '', None, True, {'a':'b'}, 
-                (1,2), [], ['reactive'], 'reaactive']
+BAD_AC_TYPES = ['foo', '', None, True, {'a': 'b'},
+                (1, 2), [], ['reactive'], 'reaactive']
+
 
 class TestMeasurement(unittest.TestCase):
     def test_check_ac_type(self):
@@ -42,7 +46,7 @@ class TestMeasurement(unittest.TestCase):
 
         # Create DataFrame
         N_COLS = len(columns)
-        df = pd.DataFrame(np.arange(N_COLS).reshape((1,N_COLS)), 
+        df = pd.DataFrame(np.arange(N_COLS).reshape((1, N_COLS)),
                           columns=measure.measurement_columns(columns))
 
         # Try accessing columns
@@ -58,17 +62,19 @@ class TestMeasurement(unittest.TestCase):
     def test_select_best_ac_type(self):
         self.assertEqual(measure.select_best_ac_type(['reactive']), 'reactive')
 
-        self.assertEqual(measure.select_best_ac_type(['active', 'reactive', 'apparent']), 'active')
+        self.assertEqual(measure.select_best_ac_type(
+            ['active', 'reactive', 'apparent']), 'active')
 
         ElecMeter.meter_devices.update(
             {'test model': {'measurements': [{'physical_quantity': 'power', 
                                               'type': 'apparent'}]}})
         meter_id = ElecMeterID(1, 1, 'REDD')
-        meter = ElecMeter(metadata={'device_model': 'test model'}, meter_id=meter_id)
+        meter = ElecMeter(metadata={'device_model': 'test model'},
+                          meter_id=meter_id)
         
-        self.assertEqual(measure.select_best_ac_type(['reactive'], 
-                                                     meter.available_power_ac_types()),
-                         'reactive')
+        self.assertEqual(measure.select_best_ac_type(
+            ['reactive'], meter.available_power_ac_types()), 'reactive')
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/nilmtk/tests/test_metergroup.py
+++ b/nilmtk/tests/test_metergroup.py
@@ -1,40 +1,44 @@
 #!/usr/bin/python
+
 from __future__ import print_function, division
+
 import unittest
 from os.path import join
-from nilmtk.tests.testingtools import data_dir
-from nilmtk import (Appliance, MeterGroup, ElecMeter, HDFDataStore, 
-                    global_meter_group, TimeFrame, DataSet)
-from nilmtk.utils import tree_root, nodes_adjacent_to_root
-from nilmtk.elecmeter import ElecMeterID
-from nilmtk.building import BuildingID
 from six import PY2
 
+from nilmtk.tests.testingtools import data_dir
+from nilmtk import Appliance, MeterGroup, ElecMeter, HDFDataStore,\
+    global_meter_group, DataSet
+from nilmtk.elecmeter import ElecMeterID
+from nilmtk.building import BuildingID
+
+
 class TestMeterGroup(unittest.TestCase):
+
     @classmethod
     def setUpClass(cls):
         filename = join(data_dir(), 'energy.h5')
         cls.datastore = HDFDataStore(filename)
         ElecMeter.load_meter_devices(cls.datastore)
-        
+
     @classmethod
     def tearDownClass(cls):
         cls.datastore.close()
 
     def test_getitem(self):
         fridge_meter = ElecMeter()
-        fridge = Appliance({'type':'fridge', 'instance':1})
+        fridge = Appliance({'type': 'fridge', 'instance': 1})
         fridge_meter.appliances = [fridge]
         mg = MeterGroup([fridge_meter])
 
         # test good keys
-        for key in ['fridge', ('fridge', 1), {'type':'fridge'}, 
-                    {'type':'fridge', 'instance': 1}]:
+        for key in ['fridge', ('fridge', 1), {'type': 'fridge'},
+                    {'type': 'fridge', 'instance': 1}]:
             self.assertEqual(mg[key], fridge_meter)
         
         # test bad key values
         for key in ['foo', ('foo', 2), ('fridge', 2), 
-                    {'type':'fridge', 'instance': -12}]:
+                    {'type': 'fridge', 'instance': -12}]:
             with self.assertRaises(KeyError):
                 mg[key]
 
@@ -45,34 +49,38 @@ class TestMeterGroup(unittest.TestCase):
 
     def test_select(self):
         fridge_meter = ElecMeter()
-        fridge = Appliance({'type':'fridge', 'instance':1})
+        fridge = Appliance({'type': 'fridge', 'instance': 1})
         fridge_meter.appliances = [fridge]
         mg = MeterGroup([fridge_meter])
 
         self.assertEqual(mg.select_using_appliances(category='cold'), mg)
         # TODO: make this test more rigorous!
-        
+
     def test_wiring_graph(self):
         meter1 = ElecMeter(metadata={'site_meter': True}, 
-                           meter_id=ElecMeterID(1,1,'REDD'))
+                           meter_id=ElecMeterID(1, 1, 'REDD'))
         meter2 = ElecMeter(metadata={'submeter_of': 1}, 
-                           meter_id=ElecMeterID(2,1,'REDD'))
+                           meter_id=ElecMeterID(2, 1, 'REDD'))
         meter3 = ElecMeter(metadata={'submeter_of': 2},
-                           meter_id=ElecMeterID(3,1,'REDD'))
+                           meter_id=ElecMeterID(3, 1, 'REDD'))
         mg = MeterGroup([meter1, meter2, meter3])
         wiring_graph = mg.wiring_graph()
-        
+
         self.assertIs(mg.mains(), meter1)
-        self.assertEqual(mg.meters_directly_downstream_of_mains().meters, [meter2])
+        self.assertEqual(mg.meters_directly_downstream_of_mains().meters,
+                         [meter2])
         if PY2:
-            self.assertEqual(list(wiring_graph.nodes()), [meter2, meter3, meter1])
+            self.assertEqual(list(wiring_graph.nodes()),
+                             [meter2, meter3, meter1])
         else:
-            self.assertEqual(list(wiring_graph.nodes()), [meter1, meter2, meter3])
+            self.assertEqual(list(wiring_graph.nodes()),
+                             [meter1, meter2, meter3])
 
     def test_proportion_of_energy_submetered(self):
         meters = []
-        for i in [1,2,3]:
-            meter_meta = self.datastore.load_metadata('building1')['elec_meters'][i]
+        for i in [1, 2, 3]:
+            meter_meta = \
+                self.datastore.load_metadata('building1')['elec_meters'][i]
             meter_id = ElecMeterID(i, 1, 'REDD')
             meter = ElecMeter(self.datastore, meter_meta, meter_id)
             meters.append(meter)
@@ -92,10 +100,11 @@ class TestMeterGroup(unittest.TestCase):
                        3: {'data_location': '/building1/elec/meter1',
                            'device_model': 'Energy Meter'}}
 
-        appliances = [{'type': 'washer dryer', 'instance': 1, 'meters': [1,2]},
+        appliances = [{'type': 'washer dryer', 'instance': 1, 'meters': [1, 2]},
                       {'type': 'fridge', 'instance': 1, 'meters': [3]}]
         mg = MeterGroup()
-        mg.import_metadata(self.datastore, elec_meters, appliances, BuildingID(1, 'REDD'))
+        mg.import_metadata(self.datastore, elec_meters, appliances,
+                           BuildingID(1, 'REDD'))
         self.assertEqual(mg['washer dryer'].total_energy()['active'], 
                          mg['fridge'].total_energy()['active'] * 2)
 
@@ -109,13 +118,16 @@ class TestMeterGroup(unittest.TestCase):
 
     def test_from_list(self):
         meters = []
-        for i in range(1,6):
+        for i in range(1, 6):
             meters.append(ElecMeter(meter_id=ElecMeterID(i, 1, None)))
             
         mg = global_meter_group.from_list([
-            ElecMeterID(1,1,None),
-            (ElecMeterID(2,1,None), 
-             (ElecMeterID(3,1,None), ElecMeterID(4,1,None), ElecMeterID(5,1,None)))
+            ElecMeterID(1, 1, None), (
+                ElecMeterID(2, 1, None), (
+                    ElecMeterID(3, 1, None), ElecMeterID(4, 1, None),
+                    ElecMeterID(5, 1, None)
+                )
+            )
         ])
         """
         Commented for the time being
@@ -134,7 +146,7 @@ class TestMeterGroup(unittest.TestCase):
         filename = join(data_dir(), 'random.h5')
         ds = DataSet(filename)
         ds.buildings[1].elec.total_energy()
-        ds.buildings[1].elec.total_energy() # test cache
+        ds.buildings[1].elec.total_energy()  # test cache
         ds.buildings[1].elec.clear_cache()
         ds.store.close()
 
@@ -151,7 +163,7 @@ class TestMeterGroup(unittest.TestCase):
         self.assertEqual(df.columns.levels, [['energy'], ['reactive']])
         df = next(elec.load(ac_type='active'))
         self.assertEqual(df.columns.levels, [['power'], ['active']])
-        
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/nilmtk/tests/test_metrics.py
+++ b/nilmtk/tests/test_metrics.py
@@ -1,15 +1,13 @@
 #!/usr/bin/python
+
 from __future__ import print_function, division
+
 import unittest
 from os.path import join
+
+from nilmtk import DataSet
 from nilmtk.tests.testingtools import data_dir
-from nilmtk import (Appliance, MeterGroup, ElecMeter, HDFDataStore, 
-                    global_meter_group, TimeFrame, DataSet)
-from nilmtk.utils import tree_root, nodes_adjacent_to_root
-from nilmtk.elecmeter import ElecMeterID
-from nilmtk.building import BuildingID
-from nilmtk.disaggregate import CombinatorialOptimisation
-from nilmtk.metrics import f1_score
+
 
 class TestMetrics(unittest.TestCase):
     @classmethod
@@ -36,6 +34,7 @@ class TestMetrics(unittest.TestCase):
         disag_elec = disag.buildings[1].elec
         f1 = f1_score(disag_elec, self.dataset.buildings[1].elec)
         """
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/nilmtk/tests/test_node.py
+++ b/nilmtk/tests/test_node.py
@@ -1,14 +1,18 @@
 #!/usr/bin/python
+
 from __future__ import print_function, division
+
 import unittest
-from ..node import find_unsatisfied_requirements
+
+from nilmtk.node import find_unsatisfied_requirements
+
 
 class TestNode(unittest.TestCase):
 
     def test_unsatisfied_requirements(self):
         requirements = {'gaps_located':True, 'energy_computed':True}
 
-        state = {'gaps_located':True}
+        state = {'gaps_located': True}
         unsatisfied = find_unsatisfied_requirements(state, requirements)
         self.assertEqual(len(unsatisfied), 1)
 

--- a/nilmtk/tests/test_timeframe.py
+++ b/nilmtk/tests/test_timeframe.py
@@ -1,7 +1,10 @@
 #!/usr/bin/python
+
 from __future__ import print_function, division
+
 import unittest
 import pandas as pd
+
 from nilmtk.timeframe import TimeFrame, merge_timeframes
 
 

--- a/nilmtk/tests/testingtools.py
+++ b/nilmtk/tests/testingtools.py
@@ -3,7 +3,11 @@ Tools to help with testing.
 """
 
 from __future__ import print_function, division
-import os, inspect, warnings
+
+import inspect
+import os
+import warnings
+
 
 def data_dir():
     # Taken from http://stackoverflow.com/a/6098238/732596
@@ -22,6 +26,7 @@ class WarningTestMixin(object):
     def assertWarns(self, warning, callable, *args, **kwds):
         with warnings.catch_warnings(record=True) as warning_list:
             warnings.simplefilter('always')
-            result = callable(*args, **kwds)
-            self.assertTrue(any(item.category == warning for item in warning_list),
-                            msg="Warning '{}' not raised.".format(warning))
+            callable(*args, **kwds)
+            self.assertTrue(
+                any(item.category == warning for item in warning_list),
+                msg="Warning '{}' not raised.".format(warning))


### PR DESCRIPTION
Looking at the converters I found some lines of code that do not satisfy the PEP8 [1] standard, plus many unused imports.
I correct and remove the lines.
After it I executed some of the unit tests and found the same kind of lines there. I correct them too.

I tried to change the less semantics as possible.

[1]. https://www.python.org/dev/peps/pep-0008/