### PR TITLE
added 3 metrics to the API

### DIFF
--- a/nilmtk/losses.py
+++ b/nilmtk/losses.py
@@ -1,4 +1,4 @@
-from sklearn.metrics import mean_squared_error, mean_absolute_error, f1_score
+from sklearn.metrics import mean_squared_error, mean_absolute_error, f1_score, r2_score
 import numpy as np
 
 def mae(app_gt,app_pred):
@@ -21,3 +21,23 @@ def relative_error(app_gt,app_pred):
     numerator = np.abs(app_gt - app_pred)
     denominator = constant + app_pred
     return np.mean(numerator/denominator)
+
+def r2score(app_gt,app_pred):
+    # https://scikit-learn.org/stable/modules/generated/sklearn.metrics.r2_score.html#sklearn.metrics.r2_score
+    return r2_score(app_gt, app_pred)
+
+def nde(app_gt,app_pred):
+    # Normalized Disaggregation Error (NDE)
+    # Inspired by http://proceedings.mlr.press/v22/zico12/zico12.pdf
+    numerator = np.sum((app_gt-app_pred)**2)
+    denominator = np.sum(app_gt**2)
+
+    return np.sqrt(numerator/denominator)
+
+def nep(app_gt,app_pred):
+    # Normalized Error in Assigned Power (NEP)
+    # Inspired by https://www.springer.com/gp/book/9783030307813
+    numerator = np.sum(np.abs(app_gt-app_pred))
+    denominator = np.sum(app_gt)
+
+    return numerator/denominator

--- a/nilmtk/version.py
+++ b/nilmtk/version.py
@@ -1,2 +1,2 @@
-version = '0.4.0.dev0'
-short_version = '0.4.0.dev0'
+version = '0.4.0.dev1+git.360c76f'
+short_version = '0.4.0'


### PR DESCRIPTION
Hi there, 

I extended the file *losses.py*. My goal was to contribute some metrics to the API. I gave it a test run and it worked out of the box:

```python
experiment = {
    'power': {
        'mains': ['apparent', 'active'],
        'appliance': ['apparent', 'active']
    },
....
....
...
        'metrics': ['nep', 'nde', 'r2score']
    }
}
```

In particular, I added the metrics R2 Score, Normalized Disaggregation Error (NDE) and Normalized Error in Assigned Power (NEP).

Have a great day,
Christoph