### PR TITLE
fix: initialize the statistics cache globally to prevent every ElecMeter to open a new file.

### DIFF
--- a/nilmtk/__init__.py
+++ b/nilmtk/__init__.py
@@ -7,13 +7,14 @@ with warnings.catch_warnings():
     from nilmtk.version import version as __version__
     from nilmtk.timeframe import TimeFrame
     from nilmtk.elecmeter import ElecMeter
-    from nilmtk.datastore import DataStore, HDFDataStore, CSVDataStore, Key
+    from nilmtk.datastore import DataStore, HDFDataStore, CSVDataStore, TmpDataStore, Key
     from nilmtk.metergroup import MeterGroup
     from nilmtk.appliance import Appliance
     from nilmtk.building import Building
     from nilmtk.dataset import DataSet
 
 global_meter_group = MeterGroup()
+STATS_CACHE = TmpDataStore()
 
 def setup_package():
     """Nosetests package setup function (run when tests are done).

--- a/nilmtk/elecmeter.py
+++ b/nilmtk/elecmeter.py
@@ -53,7 +53,7 @@ class ElecMeter(Hashable, Electric):
         self.metadata = {} if metadata is None else metadata
         assert isinstance(self.metadata, dict)
         self.store = store
-        self.cache = nilmtk.datastore.TmpDataStore()
+        self.cache = nilmtk.STATS_CACHE
         self.identifier = meter_id
 
         # Insert self into nilmtk.global_meter_group


### PR DESCRIPTION
New behavior: the TmpDataStore for caching statistics is opened once when first importing nilmtk.
All ElecMeter use the same file descriptor to this TmpDataStore cache.
Fixes: https://github.com/nilmtk/nilmtk/issues/913