### PR TITLE
Add labels to the graph of the API prediction output

### DIFF
--- a/nilmtk/api.py
+++ b/nilmtk/api.py
@@ -356,6 +356,8 @@ class API():
                         plt.xticks(rotation=90)
                     plt.title(i)
                     plt.legend()
+                    plt.xlabel('Time')
+                    plt.ylabel('Power (W)')
                 plt.show()
         
     def predict(self, clf, test_elec, test_submeters, sample_period, timezone ):


### PR DESCRIPTION
To make the graphs a bit more self explaining, labels for the axis of the
graphs are added.