### PR TITLE
Adding a feature in API for selecting specific appliance 

### DIFF
--- a/nilmtk/api.py
+++ b/nilmtk/api.py
@@ -43,6 +43,7 @@ class API():
         self.display_predictions = params.get('display_predictions', False)
         self.DROP_ALL_NANS = params.get("DROP_ALL_NANS", True)
         self.site_only = params.get('site_only',False)
+        self.specific_appliance=params.get('specific_appliance',None)
         self.experiment()
         
 

--- a/nilmtk/measurement.py
+++ b/nilmtk/measurement.py
@@ -10,7 +10,7 @@ PHYSICAL_QUANTITIES = ['power', 'energy', 'cumulative energy',
                        'voltage', 'current', 'pf', 'frequency', 'power factor', 
                        'state', 'phase angle']
 PHYSICAL_QUANTITIES_WITH_AC_TYPES = ['power', 'energy', 'cumulative energy']
-PHYSICAL_QUANTITIES_TO_AVERAGE = ['voltage', 'pf', 'frequency', 'power factor']
+PHYSICAL_QUANTITIES_TO_AVERAGE = ['voltage', 'pf', 'frequency', 'power factor','phase_angle']
 LEVEL_NAMES = ['physical_quantity', 'type']
 
 def check_ac_type(ac_type):

--- a/nilmtk/metergroup.py
+++ b/nilmtk/metergroup.py
@@ -197,7 +197,7 @@ class MeterGroup(Electric):
         * `'toaster', 2` - retrieves meter or group upstream of toaster instance 2
         * `{'dataset': 'redd', 'building': 3, 'type': 'toaster', 'instance': 2}`
           - specify an appliance
-
+        * `['light,1,17]` - retrieves ElecMeter with instance 17 for appliance-light and building-1
         Returns
         -------
         ElecMeter or MeterGroup
@@ -234,8 +234,20 @@ class MeterGroup(Electric):
                 if (set(group.identifier.meters) == key_meters):
                     return group
             raise KeyError(key)
-        # find MeterGroup from list of ElecMeterIDs
+        
         elif isinstance(key, list):
+            # Find specific appliance according to ElecMeter instance if appliance repeating more than once 
+            # If not specified then default
+            if(isinstance(key[0],str)):
+                match_meter=False
+                for meter in self.meters:
+                    if(meter.identifier.instance==key[2]):
+                        match_meter=True
+                        return meter
+                if match_meter!= True:
+                    return self[key[0]
+
+            # find MeterGroup from list of ElecMeterIDs
             if not all([isinstance(item, tuple) for item in key]):
                 raise TypeError("requires a list of ElecMeterID objects.")
             for meter in self.meters:  # TODO: write unit tests for this


### PR DESCRIPTION
In response to #888 for working on a specific appliance, if there are different meters related to the same appliance type.

Closes #888