### PR TITLE
Update metergroup.py

### DIFF
--- a/nilmtk/metergroup.py
+++ b/nilmtk/metergroup.py
@@ -717,7 +717,7 @@ class MeterGroup(Electric):
             tz = None if start.tz is None else start.tz.zone
             index = pd.date_range(
                 start.tz_localize(None), section.end.tz_localize(None), tz=tz,
-                closed='left', freq=freq)
+                inclusive='left', freq=freq)
             chunk = combine_chunks_from_generators(
                 index, columns, self.meters, kwargs)
             yield chunk


### PR DESCRIPTION
    line 718    Metergroup.py has used the object pd.date_range() for generating date in specified range.
	one of the attribute name 'closed' has been changed to 'inclusive' which exibit the same property by pandas version 1.4.0

    inclusive : {"both", "neither", "left", "right"}, default "both"
        Include boundaries; Whether to set each bound as closed or open.
        versionadded:: 1.4.0

link :- https://pandas.pydata.org/pandas-docs/version/1.4/reference/api/pandas.date_range.html


![image](https://github.com/nilmtk/nilmtk/assets/154226429/e3311bc2-8f04-419c-a272-5df1c136c9c8)
