### PR TITLE
Update goodsections.py to replace deprecated np.int with np.int64

### DIFF
--- a/nilmtk/stats/goodsections.py
+++ b/nilmtk/stats/goodsections.py
@@ -109,7 +109,7 @@ def get_good_sections(df, max_sample_period, look_ahead=None,
     timedeltas_check = concatenate(
         [[previous_chunk_ended_with_open_ended_good_section],
          timedeltas_check])
-    transitions = diff(timedeltas_check.astype(np.int))
+    transitions = diff(timedeltas_check.astype(np.int64))
 
     # Memory management
     last_timedeltas_check = timedeltas_check[-1]


### PR DESCRIPTION

File: goodsections.py 
	Issue_description: line 112, np do not have int attribute.
	Findings: latest version of numpy removed the np.int due to ambiguity with int
	Resolution: have to use np.int64
	Was written: transitions = diff(timedeltas_check.astype(np.int))
	Replace with: transitions = diff(timedeltas_check.astype(np.int64))
	Result: Susscessful



Link: https://numpy.org/devdocs/release/1.20.0-notes.html
![image](https://github.com/nilmtk/nilmtk/assets/154226429/ab94d59f-d434-43cd-b7f8-814ee4cba361)


