### PR TITLE
Updated results.py to replace deprecated dataframe.append in pandas

### DIFF
--- a/nilmtk/elecmeter.py
+++ b/nilmtk/elecmeter.py
@@ -739,7 +739,7 @@ class ElecMeter(Hashable, Electric):
                     if res.empty:
                         return res
                     else:
-                        return pd.Series(res[ac_types], index=ac_types)
+                        return pd.Series(res[list(ac_types)], index=list(ac_types))
             else:
                 return res
 

--- a/nilmtk/results.py
+++ b/nilmtk/results.py
@@ -74,7 +74,7 @@ class Results(object):
         row['end'] = timeframe.end
         for key, val in new_results.items():
             row[key] = val
-        self._data = self._data.append(row, verify_integrity=True, sort=False)
+        self._data = pd.concat([self._data , row] ,verify_integrity=True, sort=False)
         self._data.sort_index(inplace=True)
 
     def check_for_overlap(self):
@@ -105,7 +105,7 @@ class Results(object):
         if new_result._data.empty:
             return
 
-        self._data = self._data.append(new_result._data, sort=False)
+        self._data = pd.concat([self._data ,new_result._data], sort=False)
         self._data.sort_index(inplace=True)
         self.check_for_overlap()
 

--- a/nilmtk/stats/goodsections.py
+++ b/nilmtk/stats/goodsections.py
@@ -109,7 +109,7 @@ def get_good_sections(df, max_sample_period, look_ahead=None,
     timedeltas_check = concatenate(
         [[previous_chunk_ended_with_open_ended_good_section],
          timedeltas_check])
-    transitions = diff(timedeltas_check.astype(np.int))
+    transitions = diff(timedeltas_check.astype(np.int64))
 
     # Memory management
     last_timedeltas_check = timedeltas_check[-1]


### PR DESCRIPTION
File: results.py
	Issue_description: line77 , line108 : AttributeError: 'DataFrame' object has no attribute 'append'
	Findings: pandas.DataFrame.append is deprecated since version 1.4.0 . append is replace with concat() .
	Resolution: have make use of concat instead of append
	Result: Susscessful
        Link: https://pandas.pydata.org/pandas-docs/version/1.4/reference/api/pandas.DataFrame.append.html

       SS: 
![image](https://github.com/nilmtk/nilmtk/assets/154226429/d7ab5ea4-aae1-4cbf-810b-c24cc3945e2b)
