### PR TITLE
Updated results.py to replace deprecated dataframe.append in pandas

### DIFF
--- a/nilmtk/legacy/disaggregate/hart_85.py
+++ b/nilmtk/legacy/disaggregate/hart_85.py
@@ -182,8 +182,8 @@ class PairBuffer(object):
                 self.matched_pairs = pd.DataFrame(
                     new_matched_pairs, columns=self.pair_columns)
             else:
-                self.matched_pairs = self.matched_pairs.append(
-                    pd.DataFrame(new_matched_pairs, columns=self.pair_columns))
+                self.matched_pairs = pd.concat(
+                    [self.matched_pairs, pd.DataFrame(new_matched_pairs, columns=self.pair_columns)])
 
         return pairmatched
 

--- a/nilmtk/results.py
+++ b/nilmtk/results.py
@@ -74,7 +74,7 @@ class Results(object):
         row['end'] = timeframe.end
         for key, val in new_results.items():
             row[key] = val
-        self._data = self._data.append(row, verify_integrity=True, sort=False)
+        self._data = pd.concat([self._data , row] ,verify_integrity=True, sort=False)
         self._data.sort_index(inplace=True)
 
     def check_for_overlap(self):
@@ -105,7 +105,7 @@ class Results(object):
         if new_result._data.empty:
             return
 
-        self._data = self._data.append(new_result._data, sort=False)
+        self._data = pd.concat([self._data ,new_result._data], sort=False)
         self._data.sort_index(inplace=True)
         self.check_for_overlap()
 

--- a/nilmtk/results.py
+++ b/nilmtk/results.py
@@ -74,7 +74,7 @@ class Results(object):
         row['end'] = timeframe.end
         for key, val in new_results.items():
             row[key] = val
-        self._data = pd.concat([self._data , row] ,verify_integrity=True, sort=False)
+        self._data = pd.concat([self._data, row], verify_integrity=True, sort=False)
         self._data.sort_index(inplace=True)
 
     def check_for_overlap(self):
@@ -105,7 +105,7 @@ class Results(object):
         if new_result._data.empty:
             return
 
-        self._data = pd.concat([self._data ,new_result._data], sort=False)
+        self._data = pd.concat([self._data, new_result._data], sort=False)
         self._data.sort_index(inplace=True)
         self.check_for_overlap()
 


### PR DESCRIPTION
File: results.py
Issue_description: line77 , line108 : AttributeError: 'DataFrame' object has no attribute 'append'
Findings: pandas.DataFrame.append is deprecated since version 1.4.0 . append is replace with concat() .
Resolution: have make use of concat instead of append
Result: Susscessful
Link: https://pandas.pydata.org/pandas-docs/version/1.4/reference/api/pandas.DataFrame.append.html

SS

![image](https://github.com/nilmtk/nilmtk/assets/154226429/2cc77d1c-6111-4770-b442-51bf1acdd4a1)
