### PR TITLE
Updated electric.py and elecmeter.py : indexing method to list, indexing from set has been deprecated.

### DIFF
--- a/nilmtk/elecmeter.py
+++ b/nilmtk/elecmeter.py
@@ -739,7 +739,7 @@ class ElecMeter(Hashable, Electric):
                     if res.empty:
                         return res
                     else:
-                        return pd.Series(res[ac_types], index=ac_types)
+                        return pd.Series(res[list(ac_types)], index=list(ac_types))
             else:
                 return res
 

--- a/nilmtk/electric.py
+++ b/nilmtk/electric.py
@@ -294,6 +294,7 @@ class Electric(object):
         other_ac_types = other_total_energy.keys()
         self_ac_types = total_energy.keys()
         shared_ac_types = set(other_ac_types).intersection(self_ac_types)
+        shared_ac_types = list(shared_ac_types)
         n_shared_ac_types = len(shared_ac_types)
         if n_shared_ac_types > 1:
             return (total_energy[shared_ac_types] / 


### PR DESCRIPTION
        File: elecmeter.py (line 742), electric.py(line 299)
	Issue_description: TypeError: Passing a set as an indexer is not supported. Use a list instead.
	Findings: It seems that the newer version of pandas dataframe doesnot allow indexing with set or dict.
	Resolution: converting the set to list before indexing.
	Result: Susscessful

