### PR TITLE
Updated hart_85.py: changed indexer method from .ix to .loc (Dataframe.ix has been deprecated)

### DIFF
--- a/nilmtk/disaggregate/hart_85.py
+++ b/nilmtk/disaggregate/hart_85.py
@@ -526,10 +526,10 @@ class Hart85(Disaggregator):
                     # print("A", values[i], i)
                     on = True
                     i = i + 1
-                    power[i] = self.centroids.ix[appliance].values
+                    power[i] = self.centroids.loc[appliance].values
                     while values[i] != 0 and i < len(values) - 1:
                         # print("B", values[i], i)
-                        power[i] = self.centroids.ix[appliance].values
+                        power[i] = self.centroids.loc[appliance].values
                         i = i + 1
                 elif values[i] == 0:
                     # print("C", values[i], i)
@@ -562,10 +562,10 @@ class Hart85(Disaggregator):
                     else:
                         # print("H", values[i], i)
                         on = True
-                        power[i] = self.centroids.ix[appliance].values
+                        power[i] = self.centroids.loc[appliance].values
                         while values[i] != 0 and i < len(values) - 1:
                             # print("I", values[i], i)
-                            power[i] = self.centroids.ix[appliance].values
+                            power[i] = self.centroids.loc[appliance].values
                             i = i + 1
 
             di[appliance] = power


### PR DESCRIPTION
        File: legacy/disaggregate/hart_85.py 
	Issue_description: AttributeError: 'DataFrame' object has no attribute 'ix'
	Findings: Starting in 0.20.0, the .ix indexer is deprecated, in favor of the more strict .iloc and .loc indexers.
	Link: https://pandas.pydata.org/pandas-docs/version/0.23/generated/pandas.DataFrame.ix.html
	Resolution: Have using .loc instead of .ix because in the code indexing is str(columns name)