### PR TITLE
updated generate_data.py: Changed numpy array to list to resolve issue of np.int32 in timedelta

### DIFF
--- a/nilmtk/tests/generate_data.py
+++ b/nilmtk/tests/generate_data.py
@@ -23,7 +23,7 @@ def power_data(simple=True):
         STEP = 10
         data = [0,  0,  0, 100, 100, 100, 150,
                 150, 200,   0,   0, 100, 5000,    0]
-        secs = np.arange(start=0, stop=len(data) * STEP, step=STEP)
+        secs = np.arange(start=0, stop=len(data) * STEP, step=STEP).tolist()
     else:
         data = [0,  0,  0, 100, 100, 100, 150,
                 150, 200,   0,   0, 100, 5000,    0]


### PR DESCRIPTION
       File: generate_data.py, line 26
	Issue_description: python inbuilt timedelta class does not takes seconds value as np.int32.(line 26), 
	Resolution: converted numpy array to list.
	