### PR TITLE
Updated generate_data.py: converted N_PERIODS to int

### DIFF
--- a/nilmtk/tests/generate_data.py
+++ b/nilmtk/tests/generate_data.py
@@ -61,7 +61,7 @@ def power_data(simple=True):
 
 
 def create_random_df_hierarchical_column_index():
-    N_PERIODS = 1E4
+    N_PERIODS = 10000
     N_METERS = 5
     N_MEASUREMENTS_PER_METER = 3
 
@@ -84,7 +84,7 @@ MEASUREMENTS = [('power', 'active'), ('energy', 'reactive'), ('voltage', '')]
 
 
 def create_random_df():
-    N_PERIODS = 1E4
+    N_PERIODS = 10000
     rng = pd.date_range('2012-01-01', freq='S', periods=N_PERIODS)
     data = np.random.randint(
         low=0, high=1000, size=(N_PERIODS, len(MEASUREMENTS)))


### PR DESCRIPTION
File: generate_data.py , line 89
Issue_description:  'float' object cannot be interpreted as an integer(line 89).
Findings: One argument of np.random.randint(
        low=0, high=1000, size=(N_PERIODS, len(MEASUREMENTS))) ,  **size** , only takes integer value  
Resolution: N_PERIODS was equal to **1E4**  which is float , changed it to 10000 (int).