### PR TITLE
Updated hdfdatastore.py: Removed 'expectedrows' argument form self.store.put()

### DIFF
--- a/nilmtk/datastore/hdfdatastore.py
+++ b/nilmtk/datastore/hdfdatastore.py
@@ -167,7 +167,7 @@ class HDFDataStore(DataStore):
     @doc_inherit
     def put(self, key, value):
         self.store.put(key, value, format='table', 
-                       expectedrows=len(value), index=False)
+                       index=False)
         self.store.create_table_index(key, columns=['index'], 
                                       kind='full', optlevel=9)
         self.store.flush()


### PR DESCRIPTION
     File: "\datastore\hdfdatastore.py", line 169, in put
    Issue_description: TypeError: HDFStore.put() got an unexpected keyword argument 'expectedrows'
    Findings: HDFStore.put() do not have any argument name 'expectedrows'.
    Resolution: Removed the keyword 'expectedrows'