### PR TITLE
Updated couple of deprecated functionalities

### DIFF
--- a/nilmtk/datastore/hdfdatastore.py
+++ b/nilmtk/datastore/hdfdatastore.py
@@ -167,7 +167,7 @@ class HDFDataStore(DataStore):
     @doc_inherit
     def put(self, key, value):
         self.store.put(key, value, format='table', 
-                       expectedrows=len(value), index=False)
+                        index=False)
         self.store.create_table_index(key, columns=['index'], 
                                       kind='full', optlevel=9)
         self.store.flush()

--- a/nilmtk/disaggregate/fhmm_exact.py
+++ b/nilmtk/disaggregate/fhmm_exact.py
@@ -150,7 +150,7 @@ def decode_hmm(length_sequence, centroids, appliance_list, states):
         total_num_combinations *= len(centroids[appliance])
 
     for appliance in appliance_list:
-        hmm_states[appliance] = np.zeros(length_sequence, dtype=np.int)
+        hmm_states[appliance] = np.zeros(length_sequence, dtype=np.int64)
         hmm_power[appliance] = np.zeros(length_sequence)
 
     for i in range(length_sequence):

--- a/nilmtk/disaggregate/hart_85.py
+++ b/nilmtk/disaggregate/hart_85.py
@@ -526,10 +526,10 @@ class Hart85(Disaggregator):
                     # print("A", values[i], i)
                     on = True
                     i = i + 1
-                    power[i] = self.centroids.ix[appliance].values
+                    power[i] = self.centroids.loc[appliance].values
                     while values[i] != 0 and i < len(values) - 1:
                         # print("B", values[i], i)
-                        power[i] = self.centroids.ix[appliance].values
+                        power[i] = self.centroids.loc[appliance].values
                         i = i + 1
                 elif values[i] == 0:
                     # print("C", values[i], i)
@@ -562,10 +562,10 @@ class Hart85(Disaggregator):
                     else:
                         # print("H", values[i], i)
                         on = True
-                        power[i] = self.centroids.ix[appliance].values
+                        power[i] = self.centroids.loc[appliance].values
                         while values[i] != 0 and i < len(values) - 1:
                             # print("I", values[i], i)
-                            power[i] = self.centroids.ix[appliance].values
+                            power[i] = self.centroids.loc[appliance].values
                             i = i + 1
 
             di[appliance] = power

--- a/nilmtk/legacy/disaggregate/fhmm_exact.py
+++ b/nilmtk/legacy/disaggregate/fhmm_exact.py
@@ -148,7 +148,7 @@ def decode_hmm(length_sequence, centroids, appliance_list, states):
         total_num_combinations *= len(centroids[appliance])
 
     for appliance in appliance_list:
-        hmm_states[appliance] = np.zeros(length_sequence, dtype=np.int)
+        hmm_states[appliance] = np.zeros(length_sequence, dtype=np.int64)
         hmm_power[appliance] = np.zeros(length_sequence)
 
     for i in range(length_sequence):

--- a/nilmtk/tests/generate_data.py
+++ b/nilmtk/tests/generate_data.py
@@ -61,7 +61,7 @@ def power_data(simple=True):
 
 
 def create_random_df_hierarchical_column_index():
-    N_PERIODS = 1E4
+    N_PERIODS = 10000
     N_METERS = 5
     N_MEASUREMENTS_PER_METER = 3
 
@@ -84,7 +84,7 @@ MEASUREMENTS = [('power', 'active'), ('energy', 'reactive'), ('voltage', '')]
 
 
 def create_random_df():
-    N_PERIODS = 1E4
+    N_PERIODS = 10000
     rng = pd.date_range('2012-01-01', freq='S', periods=N_PERIODS)
     data = np.random.randint(
         low=0, high=1000, size=(N_PERIODS, len(MEASUREMENTS)))

--- a/nilmtk/tests/generate_data.py
+++ b/nilmtk/tests/generate_data.py
@@ -23,7 +23,7 @@ def power_data(simple=True):
         STEP = 10
         data = [0,  0,  0, 100, 100, 100, 150,
                 150, 200,   0,   0, 100, 5000,    0]
-        secs = np.arange(start=0, stop=len(data) * STEP, step=STEP)
+        secs = np.arange(start=0, stop=len(data) * STEP, step=STEP).tolist()
     else:
         data = [0,  0,  0, 100, 100, 100, 150,
                 150, 200,   0,   0, 100, 5000,    0]

--- a/setup.py
+++ b/setup.py
@@ -95,9 +95,9 @@ setup(
     packages=find_packages(),
     package_data={"": ["*.yaml"]},
     install_requires=[
-        "pandas==0.25.3",
-        "numpy >= 1.13.3, < 1.20.0",
-        "networkx==2.1",
+        "pandas>=2.1.0",
+        "numpy >= 1.26.0",
+        "networkx>=3.2.1",
         "scipy",
         "tables",
         "scikit-learn>=0.21.2",


### PR DESCRIPTION
1th Issue:
    
	File: /disaggregate/hart_85.py , line 529, 565 many places it is written
	Issue_description: AttributeError: 'DataFrame' object has no attribute 'ix'
	Findings: Starting in 0.20.0, the .ix indexer is deprecated, in favor of the more strict .iloc and .loc indexers.
	Link: https://pandas.pydata.org/pandas-docs/version/0.23/generated/pandas.DataFrame.ix.html
	Resolution: Have using .loc instead of .ix because in the code indexing is str(columns name)

2th Issue:

    File: generate_data.py, line 26
	Issue_description: python inbuilt timedelta class does not takes seconds value as np.int32.(line 26), 
	Resolution: converted numpy array to list.
	
	
	
3th Issue:
    
	File: generate_data.py , line 89
	Issue_description:  'float' object cannot be interpreted as an integer(line 89).
	Resolution: converted float variable to int.
	
4th Issue:

     File: "E:\Computer_Science\Machine_Learning\nilmtk_test\nilmtk\datastore\hdfdatastore.py", line 169, in put
     Issue_description: TypeError: HDFStore.put() got an unexpected keyword argument 'expectedrows'
	 Resolution: Removed the keyword 'expectedrows'



Below is my system configuration for different library , i am changing it accordingly

![image](https://github.com/nilmtk/nilmtk/assets/154226429/6bf4b59b-cdd2-4759-bd4b-30701a222ee0)

