### PR TITLE
Fix matplotlib version in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -103,7 +103,7 @@ setup(
         "scikit-learn>=0.21.2",
         "hmmlearn>=0.2.1",
         "pyyaml",
-        "matplotlib==3.1.3",
+        "matplotlib>=3.10.3",
         "jupyterlab"
     ],
     description="Estimate the energy consumed by individual appliances from "


### PR DESCRIPTION
Previously setup.py had "matplotlib == 3.1.3" which is an outdated version. I replaced the same with "matplotlib >= 3.10.3" which is the current version of matplotlib.