### PR TITLE
Update __init__.py to fix the pandas append error

### DIFF
--- a/nilmtk/__init__.py
+++ b/nilmtk/__init__.py
@@ -1,4 +1,10 @@
 import warnings
+import pandas as pd
+
+if not hasattr(pd.DataFrame, "append"):
+    def _df_append(self, other, ignore_index=False, verify_integrity=False, sort=False):
+        return pd.concat([self, other], ignore_index=ignore_index, verify_integrity=verify_integrity, sort=sort)
+    pd.DataFrame.append = _df_append
 
 # Silence ImportWarnings for the time being
 with warnings.catch_warnings():


### PR DESCRIPTION
This fix makes sure that the API doesn't use 'append' on a pandas DataFrame. Instead, it uses 'concat' to concatenate to the DataFrame since newer versions of pandas does not support the 'append' function.