### PR TITLE
Replace deprecated DataFrame.append() with pd.concat()

### DIFF
--- a/nilmtk/dataset_converters/dataport/csv_converter.py
+++ b/nilmtk/dataset_converters/dataport/csv_converter.py
@@ -292,7 +292,7 @@ def extract_building_data(csv_filename, b_id, b_metadata, chunksize, csv_b_cache
             if b_data.empty:
                 b_data = b_chunk
             else:
-                b_data = b_data.append(b_chunk)
+                b_data = pd.concat([b_data, b_chunk])
 
     print("\t" + " " * len(msg), end='\r')
     if not b_data.empty:

--- a/nilmtk/dataset_converters/smart/convert_smart.py
+++ b/nilmtk/dataset_converters/smart/convert_smart.py
@@ -131,8 +131,7 @@ def _convert(input_path, store, measurement_mapping_func, tz, sort_index=True):
                 df_year.insert(0, 'Date & Time', date_time_df)
                 df_year.insert(1, 'use', mains_df)
                 # Append all years data to 1 dataframe
-                df_all_years = df_all_years.append(
-                    df_year, ignore_index=True, sort=False)
+                df_all_years = pd.concat([df_all_years, df_year], ignore_index=True, sort=False)
         # Change index to datetime format
         df_all_years['Date & Time'] = pd.to_datetime(
             df_all_years['Date & Time'], utc=True)

--- a/nilmtk/disaggregate/hart_85.py
+++ b/nilmtk/disaggregate/hart_85.py
@@ -182,8 +182,7 @@ class PairBuffer(object):
                 self.matched_pairs = pd.DataFrame(
                     new_matched_pairs, columns=self.pair_columns)
             else:
-                self.matched_pairs = self.matched_pairs.append(
-                    pd.DataFrame(new_matched_pairs, columns=self.pair_columns))
+                self.matched_pairs = pd.concat([self.matched_pairs, pd.DataFrame(new_matched_pairs, columns=self.pair_columns)], ignore_index=True)
 
         return pairmatched
 

--- a/nilmtk/metrics.py
+++ b/nilmtk/metrics.py
@@ -222,9 +222,11 @@ def f1_score(predictions, ground_truth):
             aligned_states_chunk = aligned_states_chunk.astype(int)
             score = sklearn_f1_score(aligned_states_chunk.iloc[:, 0],
                                      aligned_states_chunk.iloc[:, 1])
-            scores_for_meter = scores_for_meter.append(
-                {'score': score, 'num_samples': len(aligned_states_chunk)},
-                ignore_index=True)
+            new_row = pd.DataFrame([{
+                'score': score, 
+                'num_samples': len(aligned_states_chunk)
+            }])
+            scores_for_meter = pd.concat([scores_for_meter, new_row], ignore_index=True)
 
         # Calculate weighted mean
         num_samples = scores_for_meter['num_samples'].sum()


### PR DESCRIPTION
Replace deprecated DataFrame.append() with pd.concat() as newer version of pandas has discontinued use of append().