### PR TITLE
Fix data converter for the HIPE dataset

### DIFF
--- a/nilmtk/dataset_converters/__init__.py
+++ b/nilmtk/dataset_converters/__init__.py
@@ -12,3 +12,4 @@ from .iawe.convert_iawe import convert_iawe
 from .smart.convert_smart import convert_smart
 from .caxe.convert_caxe import convert_caxe
 from .ideal.convert_ideal import convert_ideal
+from .hipe.convert_hipe import convert_hipe

--- a/nilmtk/dataset_converters/hipe/convert_hipe.py
+++ b/nilmtk/dataset_converters/hipe/convert_hipe.py
@@ -35,7 +35,10 @@ def convert_hipe(hipe_path, output_filename, format="HDF"):
     _convert(hipe_path, datastore,
              _hipe_measurement_mapping_func, "Europe/Berlin")
 
-    metadata_path = "metadata"
+    metadata_path = join(get_module_directory(),
+                              'dataset_converters',
+                              'hipe',
+                              'metadata')
 
     save_yaml_to_datastore(metadata_path, datastore)
 
@@ -69,7 +72,7 @@ def _convert(input_path,
 
     check_directory_exists(input_path)
 
-    print("Loading factory 1...", end="... ")
+    print("Loading factory 1...", end="... \n")
     chans = _find_all_channels(input_path, meter_to_machine)
     for chan_id, filename in chans.items():
         print(chan_id, end=" ")
@@ -96,7 +99,7 @@ def _load_csv(filename, measurements, drop_duplicates=False, sort_index=False):
     print(f"Processing {filename}")
     df = pd.read_csv(filename, usecols=["SensorDateTime", "P_kW"], index_col=0)
 
-    df.index = pd.to_datetime(df.index, utc=True)
+    df.index = pd.to_datetime(df.index, utc=True, format='mixed')
     df = df.tz_convert("Europe/Berlin")
     df["P_kW"] *= 1000  # convert kW to W
 


### PR DESCRIPTION
Hi,

While converting the HIPE dataset, I received several errors.

- The metadata path was hardcoded as 'metadata', which has been changed to the path in the NILMTK package folder.

```python
metadata_path = join(get_module_directory(),
                              'dataset_converters', 
                              'hipe', 
                              'metadata')
```

- Besides, the timestamps in the dataset sometimes miss the microsecond, which has been fixed using format='mixed'.

```python
df.index = pd.to_datetime(df.index, utc=True, format='mixed')
```

- Lastly, the `convert_hipe` module was not imported in `__init__.py`

```
from .hipe.convert_hipe import convert_hipe
```
