### PR TITLE
Replace np.NaN with np.nan

### DIFF
--- a/nilmtk/electric.py
+++ b/nilmtk/electric.py
@@ -258,7 +258,7 @@ class Electric(object):
         else:
             td = self.get_timeframe().timedelta
         if not td:
-            return np.NaN
+            return np.nan
         uptime_secs = td.total_seconds()
         periods = uptime_secs / offset_alias_to_seconds(offset_alias)
         energy = self.total_energy(**load_kwargs)
@@ -285,7 +285,7 @@ class Electric(object):
         # TODO test effect of setting `sections` for other
         other_total_energy = other.total_energy(**loader_kwargs)
         if other_total_energy.sum() == 0:
-            return np.NaN
+            return np.nan
 
         total_energy = self.total_energy(**loader_kwargs)
         if total_energy.empty:
@@ -336,11 +336,11 @@ class Electric(object):
 
         x_n, x_sum = sum_and_count(self)
         if x_n <= 1:
-            return np.NaN
+            return np.nan
 
         y_n, y_sum = sum_and_count(other)
         if y_n <= 1:
-            return np.NaN
+            return np.nan
 
         x_bar = x_sum / x_n 
         y_bar = y_sum / y_n

--- a/nilmtk/metergroup.py
+++ b/nilmtk/metergroup.py
@@ -1093,7 +1093,7 @@ class MeterGroup(Electric):
                 print("   {:.2%}".format(prop))
         
         if all_nan:
-            proportion = np.NaN
+            proportion = np.nan
         return proportion
 
     def available_ac_types(self, physical_quantity):
@@ -1718,7 +1718,7 @@ class MeterGroup(Electric):
             series['proportion_uptime'] = (mains_uptime.total_seconds() /
                                            timeframe.timedelta.total_seconds())
         except ZeroDivisionError:
-            series['proportion_uptime'] = np.NaN
+            series['proportion_uptime'] = np.nan
         series['average_mains_energy_per_day'] = self.mains().average_energy_per_period()
 
         return series
@@ -1787,7 +1787,7 @@ def combine_chunks_from_generators(index, columns, meters, kwargs):
     # See http://stackoverflow.com/a/27526721/732596
 
     DTYPE = np.float32
-    cumulator = pd.DataFrame(np.NaN, index=index, columns=columns, dtype=DTYPE)
+    cumulator = pd.DataFrame(np.nan, index=index, columns=columns, dtype=DTYPE)
     cumulator_arr = cumulator.values
     columns_to_average_counter = pd.DataFrame(dtype=np.uint16)
     timeframe = None
@@ -1827,7 +1827,7 @@ def combine_chunks_from_generators(index, columns, meters, kwargs):
             where_both_are_nan = np.isnan(cumulator_col) & np.isnan(aligned)
             np.nansum([cumulator_col, aligned], axis=0, out=cumulator_col, 
                       dtype=DTYPE)
-            cumulator_col[where_both_are_nan] = np.NaN
+            cumulator_col[where_both_are_nan] = np.nan
             del aligned
             del where_both_are_nan
             gc.collect()

--- a/nilmtk/metrics.py
+++ b/nilmtk/metrics.py
@@ -240,7 +240,7 @@ def f1_score(predictions, ground_truth):
             warn("No aligned samples when calculating F1-score for prediction"
                  " meter {} and ground truth meter {}."
                  .format(pred_meter, ground_truth_meter))
-            avg_score = np.NaN
+            avg_score = np.nan
         f1_scores[pred_meter.instance()] = avg_score
 
     return pd.Series(f1_scores)

--- a/nilmtk/stats/dropoutrate.py
+++ b/nilmtk/stats/dropoutrate.py
@@ -39,7 +39,7 @@ def get_dropout_rate(data, sample_period):
     """
     MIN_N_SAMPLES = 5
     if len(data) < MIN_N_SAMPLES:
-        return np.NaN
+        return np.nan
 
     index = get_index(data)
     assert(index[-1] > index[0])

--- a/nilmtk/utils.py
+++ b/nilmtk/utils.py
@@ -334,7 +334,7 @@ def normalise_timestamp(timestamp, freq):
     in the set of timestamps returned by pd.DataFrame.resample(freq=freq)
     """
     timestamp = pd.Timestamp(timestamp)
-    series = pd.Series(np.NaN, index=[timestamp])
+    series = pd.Series(np.nan, index=[timestamp])
     resampled = series.resample(freq).mean()
     return resampled.index[0]
 
@@ -434,7 +434,7 @@ def compute_rmse(ground_truth, predictions, pretty=True):
         if not df_app.empty:
             app_rms_error = np.sqrt(mean_squared_error(df_app['gt'], df_app['pr']))
         else:
-            app_rms_error = np.NaN
+            app_rms_error = np.nan
 
         if pretty:
             app_counts[app_label] += 1


### PR DESCRIPTION
Hi,

Thanks for making it so much easier to work with NILM dataset.

When I tried to load the dataframe:

```python
import nilmtk
import pandas as pd

redd = nilmtk.DataSet("redd.h5")

building_1 = redd.buildings[1]
fridge = building_1.elec['fridge']

fridge_df = pd.DataFrame(list(fridge.load())[0])
```

There was an error:

```
AttributeError: np.NaN was removed in the NumPy 2.0 release. Use np.nan instead.
```

It looks like `np.NaN`  has been deprecated and should be replaced with `np.nan`.
