### PR TITLE
Pin NILM Metadata to an immutable revision

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ classifiers = [
 # Essential dependencies only (based on current NILMTK codebase)
 dependencies = [
     "ipython>=8.7.0",
-    "nilm_metadata @ git+https://github.com/nilmtk/nilm_metadata.git",
+    "nilm_metadata @ git+https://github.com/nilmtk/nilm_metadata.git@59c9990de4836d77c0dcd807bd4293e39e0cc314",
     "nose",
     # Core scientific computing (Windows-compatible versions)
     "numpy>=1.24.0",

--- a/tests/test_packaging_contracts.py
+++ b/tests/test_packaging_contracts.py
@@ -1,0 +1,20 @@
+import tomllib
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+NILM_METADATA_REQUIREMENT = (
+    "nilm_metadata @ git+https://github.com/nilmtk/nilm_metadata.git"
+    "@59c9990de4836d77c0dcd807bd4293e39e0cc314"
+)
+
+
+def test_nilm_metadata_is_pinned_to_an_immutable_commit():
+    with (PROJECT_ROOT / "pyproject.toml").open("rb") as handle:
+        dependencies = tomllib.load(handle)["project"]["dependencies"]
+
+    matching = [
+        requirement
+        for requirement in dependencies
+        if requirement.partition(" @ ")[0].replace("_", "-") == "nilm-metadata"
+    ]
+    assert matching == [NILM_METADATA_REQUIREMENT]


### PR DESCRIPTION
## Summary

- pin `nilm_metadata` to a verified immutable commit instead of floating Git HEAD
- add a packaging regression test so the dependency cannot silently become mutable again

The selected commit is the current upstream head and includes SIDED industrial appliance metadata.

## Verification

- packaging contract test passes
- Ruff passes for the new test
- source distribution and wheel build successfully
- built wheel metadata contains the exact 40-character `nilm_metadata` revision

This small prerequisite lets downstream containers and packages pin NILMTK transitively without conflicting direct URLs.
