### PR TITLE
Make NILMTK onboarding verifiable

### DIFF
--- a/.github/workflows/docs-checks.yml
+++ b/.github/workflows/docs-checks.yml
@@ -1,0 +1,30 @@
+name: Documentation and package checks
+
+on:
+  pull_request:
+  push:
+    branches: [master]
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+      - uses: astral-sh/setup-uv@v6
+        with:
+          version: "0.11.28"
+          enable-cache: true
+      - name: Check onboarding and links
+        run: python3 scripts/check_docs.py
+      - name: Build source and wheel artifacts
+        run: uv build
+      - name: Test the dataset converter command
+        run: >-
+          uv run --no-dev --with pytest --with pytest-cov
+          pytest -q tests/test_converter_cli.py tests/test_packaging_contracts.py

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@ build
 *.pyc
 *.*~
 *.log
+.coverage
+htmlcov/
+uv.lock
 profile.txt
 *.so
 build/
@@ -26,4 +29,3 @@ data/ukdale
 *.h5
 *.tar
 *.dat
-

--- a/README.md
+++ b/README.md
@@ -1,97 +1,167 @@
-# NILMTK: Non-Intrusive Load Monitoring Toolkit
+# NILMTK core
 
-Non-Intrusive Load Monitoring (NILM) is the process of estimating the
-energy consumed by individual appliances given just a whole-house
-power meter reading.  In other words, it produces an (estimated)
-itemised energy bill from just a single, whole-house power meter.
+NILMTK is the data and evaluation layer of the open-source ecosystem for
+non-intrusive load monitoring (NILM). It converts and loads energy datasets,
+represents buildings and meters, prepares time windows, computes statistics and
+metrics, and provides classical reference algorithms.
 
-NILMTK is a toolkit designed to help **researchers** evaluate the accuracy of NILM algorithms. If you are a new Python user, it is recommended to educate yourself on [Pandas](https://pandas.pydata.org/), [Pytables](http://www.pytables.org/) and other tools from the Python ecosystem.
+**Use this repository when your work is about data, meters, preprocessing, or
+metrics.** For maintained neural models or reproducible benchmark claims, use
+the companion repositories below.
 
-**⚠️It may take time for the NILMTK authors to get back to you regarding queries/issues. However, you are more than welcome to propose changes, support!** Remember to check existing issue tickets, especially the open ones.
+## Choose the right repository
 
-# Documentation
+| Job | Canonical repository |
+| --- | --- |
+| Convert, load, inspect, and score energy data | **[NILMTK core](https://github.com/nilmtk/nilmtk)** — this repository |
+| Resolve appliance names, synonyms, meters, and dataset semantics | [NILM Metadata](https://github.com/nilmtk/nilm_metadata) |
+| Use or contribute a disaggregation model | [nilmtk-contrib](https://github.com/nilmtk/nilmtk-contrib) |
+| Reproduce T1/T2/T3 protocols or publish a leaderboard result | [NILMbench](https://github.com/nilmtk/nilmbench) |
 
-[NILMTK Documentation](https://github.com/nilmtk/nilmtk/tree/master/docs/manual)
+The [NILMTK ecosystem guide](https://nilmtk.github.io/) explains how these
+layers fit together, which Docker route to use, and which papers to cite.
 
-# Installation
+## Supported installation
 
-## UV Support
-This Python package uses uv for installation. uv is a fast and modern Python package manager that replaces tools like pip and virtualenv, with support for pyproject.toml and ultra-fast dependency resolution. 
+NILMTK core supports Python 3.11 and newer. Use Python 3.11 for an end-to-end
+environment shared with nilmtk-contrib and NILMbench.
 
-To install NILMTK, first install [uv](https://docs.astral.sh/uv/getting-started/installation/) and then run:<br>
-```
-uv pip install git+https://github.com/nilmtk/nilmtk.git
-```
+Install [uv](https://docs.astral.sh/uv/getting-started/installation/), then create
+an isolated environment:
 
-To use the `deddiag` dataset, install the optional dependency with:
-```
-uv pip install "nilmtk[deddiag] @ git+https://github.com/nilmtk/nilmtk
-```
-
-## Docker Support
-Docker is an open-source platform for developing, shipping, and running applications in lightweight, portable containers that bundle code, runtime, libraries, and system tools into a single package. It ensures everyone runs the same environment, regardless of host OS, and keeps NILMTK’s dependencies contained without polluting the system Python.
-
-
-Build and run locally
-```
-docker build -t nilmtk-uv .
-docker run --rm -it nilmtk-uv bash
-```
-Pull the pre-built image
-```
-docker pull ghcr.io/enfuego27826/nilmtk:latest
-docker run --rm -it ghcr.io/enfuego27826/nilmtk:latest bash
+```bash
+uv venv --python 3.11
+source .venv/bin/activate
+uv pip install "nilmtk @ git+https://github.com/nilmtk/nilmtk.git"
+python -c "import nilmtk; print(nilmtk.__version__)"
 ```
 
-It came to our attention that some users follow third-party tutorials to install NILMTK. Always remember to check the dates of such tutorials, many are very outdated and don't reflect NILMTK's current version or the recommended/supported setup.
+On Windows PowerShell, activate the environment with
+`.venv\Scripts\Activate.ps1`.
 
-# Why a toolkit for NILM?
+To use the DEDDIAG converter, install the optional extra:
 
-We quote our [NILMTK paper](http://arxiv.org/pdf/1404.3878v1.pdf)
-explaining the need for a NILM toolkit:
+```bash
+uv pip install "nilmtk[deddiag] @ git+https://github.com/nilmtk/nilmtk.git"
+```
 
-  > Empirically comparing disaggregation algorithms is currently
-  > virtually impossible. This is due to the different data sets used,
-  > the lack of reference implementations of these algorithms and the
-  > variety of accuracy metrics employed.
+Do not combine these instructions with old Python 3.6, Anaconda-channel, or
+`setup.py develop` tutorials. Those routes describe earlier releases and are
+not the supported installation for the current repository.
 
+### Verify the command-line converter
 
-# What NILMTK provides
+```bash
+nilmtk-convert --help
+nilmtk-convert list
+# Example after downloading REDD:
+nilmtk-convert redd /path/to/low_freq /path/to/redd.h5
+```
 
-To address this challenge, we present the Non-intrusive Load Monitoring
-Toolkit (NILMTK); an open source toolkit designed specifically to enable
-the comparison of energy disaggregation algorithms in a reproducible
-manner. This work is the first research to compare multiple
-disaggregation approaches across multiple publicly available data sets.
-NILMTK includes:
+Dataset-specific converter arguments and source links live under
+[`nilmtk/dataset_converters`](nilmtk/dataset_converters).
 
--  parsers for a range of existing data sets (8 and counting)
--  a collection of preprocessing algorithms
--  a set of statistics for describing data sets
--  a number of [reference benchmark disaggregation algorithms](https://github.com/nilmtk/nilmtk/wiki/NILM-Algorithms)
--  a common set of accuracy metrics
--  and much more!
+## Docker ownership
 
-# Publications
+NILMTK core is a Python library and does not publish a separate official core
+image. This is intentional:
 
-If you use NILMTK in academic work then please consider citing our papers. Here are some of the publications (contributors, please update this as required):
+- use the single [nilmtk-contrib Dockerfile](https://github.com/nilmtk/nilmtk-contrib)
+  for a general environment containing core, metadata, and model code;
+- use [NILMbench](https://github.com/nilmtk/nilmbench) for pinned CPU-smoke and
+  CUDA-benchmark runtimes that certify leaderboard results;
+- do not create an image for each algorithm.
 
-1. Nipun Batra, Jack Kelly, Oliver Parson, Haimonti Dutta, William Knottenbelt, Alex Rogers, Amarjeet Singh, Mani Srivastava. NILMTK: An Open Source Toolkit for Non-intrusive Load Monitoring. In: 5th International Conference on Future Energy Systems (ACM e-Energy), Cambridge, UK. 2014. DOI:[10.1145/2602044.2602051](http://dx.doi.org/10.1145/2602044.2602051). arXiv:[1404.3878](http://arxiv.org/abs/1404.3878).
-2. Nipun Batra, Jack Kelly, Oliver Parson, Haimonti Dutta, William Knottenbelt, Alex Rogers, Amarjeet Singh, Mani Srivastava. NILMTK: An Open Source Toolkit for Non-intrusive Load Monitoring". In: NILM Workshop, Austin, US. 2014 \[[pdf](http://nilmworkshop14.files.wordpress.com/2014/05/batra_nilmtk.pdf)\]
-3. Jack Kelly, Nipun Batra, Oliver Parson, Haimonti Dutta, William Knottenbelt, Alex Rogers, Amarjeet Singh, Mani Srivastava. Demo Abstract: NILMTK v0.2: A Non-intrusive Load Monitoring Toolkit for Large Scale Data Sets. In the first ACM Workshop On Embedded Systems For Energy-Efficient Buildings, 2014. DOI:[10.1145/2674061.2675024](http://dx.doi.org/10.1145/2674061.2675024). arXiv:[1409.5908](http://arxiv.org/abs/1409.5908).
-4. Nipun Batra, Rithwik Kukunuri, Ayush Pandey, Raktim Malakar, Rajat Kumar, Odysseas Krystalakos, Mingjun Zhong, Paulo Meira, and Oliver Parson. 2019. Towards reproducible state-of-the-art energy disaggregation. In Proceedings of the 6th ACM International Conference on Systems for Energy-Efficient Buildings, Cities, and Transportation (BuildSys '19). Association for Computing Machinery, New York, NY, USA, 193–202. DOI:[10.1145/3360322.3360844](https://doi.org/10.1145/3360322.3360844)
+Keeping container ownership in those two places prevents four repositories from
+shipping drifting copies of the same environment.
 
-Please note that NILMTK has evolved *a lot* since most of these papers were published! Please use the [online docs](https://github.com/nilmtk/nilmtk/tree/master/docs/manual)
-as a guide to the current API. 
+## Data
 
-# Brief history
+NILMTK does not redistribute REDD, UK-DALE, REFIT, or other licensed datasets.
+Download data from its official custodian, comply with its license, and convert
+it locally. A converted HDF5 dataset can then be opened with:
 
-* August 2019: v0.4 released with the new API. See also [NILMTK-Contrib](https://github.com/nilmtk/nilmtk-contrib).
-* June 2019: v0.3.1 released on [Anaconda Cloud](https://anaconda.org/nilmtk/nilmtk/).
-* Jav 2018: Initial Python 3 support on the v0.3 branch
-* Nov 2014: NILMTK wins best demo award at [ACM BuildSys](http://www.buildsys.org/2014/)
-* July 2014: v0.2 released
-* June 2014: NILMTK presented at [ACM e-Energy](http://conferences.sigcomm.org/eenergy/2014/)
-* April 2014: v0.1 released
+```python
+from nilmtk import DataSet
 
-For more detail, please see our [changelog](https://github.com/nilmtk/nilmtk/blob/master/docs/manual/development_guide/changelog.md).
+dataset = DataSet("redd.h5")
+print(dataset.metadata)
+print(dataset.buildings)
+```
+
+NILM Metadata is installed with core and supplies the canonical appliance
+taxonomy, synonyms, and meter relationships used while loading datasets.
+
+## What core provides
+
+- converters for public energy datasets;
+- lazy access to buildings, meters, appliances, and time frames;
+- resampling, alignment, preprocessing, and data-quality statistics;
+- standard NILM accuracy and energy metrics;
+- the rapid experimentation API used by nilmtk-contrib;
+- classical reference disaggregators and baseline utilities.
+
+Detailed API reference is published at
+[nilmtk.github.io/nilmtk/master](https://nilmtk.github.io/nilmtk/master/index.html).
+The repository manual and notebooks live under [`docs/manual`](docs/manual).
+
+## Development
+
+```bash
+git clone https://github.com/nilmtk/nilmtk.git
+cd nilmtk
+uv sync --extra dev
+uv run pytest tests
+```
+
+Before opening a pull request, run the narrow test for your change, the current
+package gate, and the documentation contract:
+
+```bash
+uv run pytest tests
+uv run python scripts/check_docs.py
+uv build
+```
+
+The historical core regression tests live under `nilmtk/tests` and
+`nilmtk/stats/tests`. Run the affected files explicitly when changing those
+modules; work to bring those fixtures into the default gate is tracked
+separately.
+
+Changes to dataset semantics belong in NILM Metadata. New model architectures
+belong in nilmtk-contrib. Benchmark task definitions and published result
+bundles belong in NILMbench.
+
+## Citation
+
+If you use core dataset conversion, meter abstractions, preprocessing, or
+metrics, cite the NILMTK paper:
+
+```bibtex
+@inproceedings{batra2014nilmtk,
+  title     = {NILMTK: An Open Source Toolkit for Non-intrusive Load Monitoring},
+  author    = {Batra, Nipun and Kelly, Jack and Parson, Oliver and Dutta, Haimonti
+               and Knottenbelt, William and Rogers, Alex and Singh, Amarjeet
+               and Srivastava, Mani},
+  booktitle = {Proceedings of the 5th ACM International Conference on Future
+               Energy Systems},
+  year      = {2014},
+  pages     = {265--276},
+  doi       = {10.1145/2602044.2602051}
+}
+```
+
+Also cite the [NILM Metadata paper](https://doi.org/10.1109/COMPSACW.2014.97)
+when relying on its schema or taxonomy, the
+[nilmtk-contrib paper](https://doi.org/10.1145/3360322.3360844) when using its
+model suite, and the [NILMBench2026 paper](https://doi.org/10.1145/3744256.3812587)
+when using its protocols, runner, or leaderboard results. Always cite the
+original model and dataset papers as well.
+
+## Help and license
+
+Search [existing issues](https://github.com/nilmtk/nilmtk/issues) before opening
+a report. Include the exact command, operating system, Python version, dataset
+identity, and a minimal reproducer.
+
+NILMTK is released under the [Apache License 2.0](LICENSE).

--- a/docs/manual/user_guide/install_dev.md
+++ b/docs/manual/user_guide/install_dev.md
@@ -1,60 +1,63 @@
+# Develop NILMTK core
 
-# Install NILMTK
+Use Python 3.11 and uv so local development matches the ecosystem's supported
+research environment.
 
-We recommend using [Anaconda](https://www.anaconda.com/distribution/), which bundles togther most of the required packages. NILMTK requires Python 3.6+ due to the module it depends upon.
-
-If you prefer to avoid Anaconda, you could install most packages using `pip` but you will require a compatible C compiler for your Python distribution. Be sure to use the package versions listed in the file `environment-dev.yml`.
-
-Before anything, install Anaconda. If you already have it installed, be sure to keep it updated.
-
-The following instructions are general enough to work on Linux, macOS or Windows (run the commands on a Powershell session). Remember to adapt it to your environment.
-
-1. Install Git, if not available. On Linux, install using your distribution package manager, e.g.:
+## Clone and install
 
 ```bash
-sudo apt-get install git
-```
-
-On Windows, download and installation the official [Git](http://git-scm.com/download/win) client.
-
-Alternatively, if you do not have administrator access, you can install Git directly on the Anaconda distribution running `conda install git`.
-
-2. Download NILMTK:
-
-```bash
-cd ~
 git clone https://github.com/nilmtk/nilmtk.git
 cd nilmtk
+uv sync --extra dev
 ```
 
-The next step creates a separate environment for NILMTK (see [the Anaconda documentation]((https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html))), using NILMTK's `environment-dev.yml` text file to define which packages need to be installed. If you have a previous `nilmtk-env` environment, please remove it first (`conda env remove -n nilmtk-env`).
+The project metadata installs the reviewed NILM Metadata revision required by
+core. You do not need to run `setup.py` or install a separate Conda environment.
+
+## Run checks
+
+Start with the narrowest test that covers your change, then run the current
+package gate:
 
 ```bash
-conda env create -f environment-dev.yml
-conda activate nilmtk-env
+uv run pytest path/to/test_file.py
+uv run pytest tests
+uv run python scripts/check_docs.py
+uv build
 ```
 
-Next we will install [nilm_metadata](https://github.com/nilmtk/nilm_metadata) (for development, we recommend installing from the repository, even though there is a conda package available):
+The historical regression tests live under `nilmtk/tests` and
+`nilmtk/stats/tests`. Run the affected files explicitly when changing core or
+statistics behavior; their legacy HDF fixtures are being modernized before the
+directories join default discovery.
+
+## Work on core and metadata together
+
+Clone the repositories as siblings and install metadata editably only when your
+change genuinely crosses the schema boundary:
 
 ```bash
-cd ~
-git clone https://github.com/nilmtk/nilm_metadata/
-cd nilm_metadata
-python setup.py develop
 cd ..
+git clone https://github.com/nilmtk/nilm_metadata.git
+cd nilmtk
+uv pip install -e ../nilm_metadata
 ```
 
-Change back to your nilmtk directory and install NILMTK:
+Changes to appliance taxonomy, synonyms, schema, or meter semantics belong in
+[NILM Metadata](https://github.com/nilmtk/nilm_metadata). New architectures
+belong in [nilmtk-contrib](https://github.com/nilmtk/nilmtk-contrib), and frozen
+benchmark protocols or result bundles belong in
+[NILMbench](https://github.com/nilmtk/nilmbench).
 
-```bash
-cd ~/nilmtk
-python setup.py develop
-```
+## Pull request evidence
 
-Run the unit tests:
+Include:
 
-```bash
-nosetests
-```
+- the failure or missing behavior your change addresses;
+- focused regression tests, including malformed or boundary inputs;
+- every test command and outcome, including known failures;
+- dataset identity and a minimal reproducible window when data behavior changes;
+- documentation updates when a public contract changes.
 
-Then, work away on NILMTK!  When you are done, just do `conda deactivate` to deactivate the nilmtk-env (or just clone the terminal/session).
+Do not commit licensed datasets, credentials, generated environments, or local
+HDF5 outputs.

--- a/docs/manual/user_guide/install_user.md
+++ b/docs/manual/user_guide/install_user.md
@@ -1,89 +1,69 @@
-# Installing NILMTK
+# Install NILMTK core
 
-We recommend using [Anaconda](https://store.continuum.io/cshop/anaconda/), which bundles together most of the required packages. NILMTK requires Python 3.6+ due to the module it depends upon.
+These instructions describe the current repository. NILMTK core supports
+Python 3.11 and newer; use Python 3.11 when sharing an environment with
+nilmtk-contrib or NILMbench.
 
-After Anaconda has been installed, open up the terminal (Unix) or Anaconda prompt (Windows):
+## 1. Install uv
 
-1.  NILMTK should work fine in the base environment, but we recommend creating a new environment where NILMTK and related dependecies are installed.
-
-	```bash
-	conda create --name nilmtk-env 
-	```
-
-2. Add conda-forge to list of channels to be searched for packages.
-	```bash
-	conda config --add channels conda-forge
-	```
-
-3. Activate the new *nilmtk-env* environment.
-
-	```bash
-	conda activate nilmtk-env
-	```
-
-4. Install the NILMTK package
-
-	```bash
-	conda install -c nilmtk nilmtk
-	```
-	
-    This will install the latest version of nilmtk. As of June 2023 is the lastest version if nilmtk 0.4.3. You can equivalently use `conda install -c nilmtk nilmtk=0.4.3`.
-    For older versions, you may need to specify versions for other packages in order to get a working environment. E.g. for NILMTK v0.4.1, use `conda install -c nilmtk nilmtk=0.4.1 matplotlib=3.1.3`. It should be noted that as of June 2023 the only version available on the channels of anaconda.org is the version 0.4.3, attempts to install older version may lead to errors such as "PackageNotFoundError" on the terminal.
-
-5. The installed package import for python/ ipython can be  tested in the terminal using the following command:
-	```bash
-	python -c "import nilmtk"
-	```
-	or	
-	```bash
-	ipython -c "import nilmtk"
-	```
-	> Note: This might show DepreciationWarning due to the *imp* module. That will be fixed in a future release.
-
-	* Alternatively, you can also run your IDE in *nilmtk-env* from: Anaconda Navigator > "Applications on" dropdown > nilmtk-env
-	To check the current environment variables,
-
-		```python
-		import sys
-		print(sys.executable)
-		print(sys.version)
-		```
-		You will see an output similar to:
-		```
-		/home/ayush/anaconda3/envs/nilmtk-env/bin/python
-		3.6.7 | packaged by conda-forge | (default, Feb 28 2019, 09:07:38) 
-		[GCC 7.3.0]
-		```
-6. Run your Python IDE from this environment, for example:
-
-	```bash
-	jupyter notebook
-	```
-	or
-
-	```bash
-	spyder
-	```
-
-7. Import NILMTK in the IDE:
-
-	```python
-	import nilmtk
-	```
-	The package modules can now be used.
-8. To deactivate this environment,
-
-	```bash
-	conda deactivate
-	```
-    
-We recommend checking the [Anaconda documentation about environments](https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html) if the concept is new to you.
-
-
-# Conda development snapshots
-
-If you want to try out tagged development versions, you can follow the normal installation guide but use the following command for the NILMTK installation (step 4):
+Follow the official [uv installation guide](https://docs.astral.sh/uv/getting-started/installation/),
+then confirm the command is available:
 
 ```bash
-    conda install -c nilmtk -c nilmtk/label/dev nilmtk
+uv --version
 ```
+
+## 2. Create an isolated environment
+
+```bash
+uv venv --python 3.11
+source .venv/bin/activate
+```
+
+On Windows PowerShell:
+
+```powershell
+.venv\Scripts\Activate.ps1
+```
+
+## 3. Install core
+
+```bash
+uv pip install "nilmtk @ git+https://github.com/nilmtk/nilmtk.git"
+```
+
+For the optional DEDDIAG converter:
+
+```bash
+uv pip install "nilmtk[deddiag] @ git+https://github.com/nilmtk/nilmtk.git"
+```
+
+## 4. Verify the installation
+
+```bash
+python -c "import nilmtk; print(nilmtk.__version__)"
+nilmtk-convert --help
+```
+
+## 5. Choose the next layer
+
+- Continue with core if you need converters, meters, preprocessing, or metrics.
+- Install [nilmtk-contrib](https://github.com/nilmtk/nilmtk-contrib) if you need
+  maintained disaggregation models.
+- Use [NILMbench](https://github.com/nilmtk/nilmbench) if you need frozen
+  real-data protocols and comparable leaderboard results.
+- Read the [ecosystem guide](https://nilmtk.github.io/) for Docker ownership and
+  citation guidance.
+
+## Data is separate
+
+Public datasets have their own licenses and download processes. NILMTK does not
+bundle them. Obtain each dataset from its official custodian and convert it
+locally with the matching module under
+[`nilmtk/dataset_converters`](../../../nilmtk/dataset_converters).
+
+## Avoid stale installation guides
+
+Instructions based on Python 3.6, the historical NILMTK Anaconda channel, or
+`setup.py develop` refer to earlier releases. Do not mix them with this uv-based
+environment.

--- a/nilmtk/__init__.py
+++ b/nilmtk/__init__.py
@@ -1,3 +1,4 @@
+import atexit
 import warnings
 import pandas as pd
 
@@ -21,6 +22,7 @@ with warnings.catch_warnings():
 
 global_meter_group = MeterGroup()
 STATS_CACHE = TmpDataStore()
+atexit.register(STATS_CACHE.close)
 
 def setup_package():
     """Nosetests package setup function (run when tests are done).

--- a/nilmtk/dataset_converters/cli.py
+++ b/nilmtk/dataset_converters/cli.py
@@ -1,0 +1,172 @@
+"""Command-line dispatcher for NILMTK's path-based dataset converters."""
+
+from __future__ import annotations
+
+import argparse
+import importlib
+from collections.abc import Sequence
+from dataclasses import dataclass
+from pathlib import Path
+
+from nilmtk.version import version
+
+
+@dataclass(frozen=True)
+class ConverterSpec:
+    module: str
+    function: str
+    description: str
+
+
+CONVERTERS = {
+    "ampds": ConverterSpec(
+        "nilmtk.dataset_converters.ampds.convert_ampds",
+        "convert_ampds",
+        "AMPds",
+    ),
+    "combed": ConverterSpec(
+        "nilmtk.dataset_converters.combed.convert_combed",
+        "convert_combed",
+        "COMBED",
+    ),
+    "dred": ConverterSpec(
+        "nilmtk.dataset_converters.dred.convert_dred",
+        "convert_dred",
+        "DRED",
+    ),
+    "hes": ConverterSpec(
+        "nilmtk.dataset_converters.hes.convert_hes",
+        "convert_hes",
+        "HES",
+    ),
+    "hipe": ConverterSpec(
+        "nilmtk.dataset_converters.hipe.convert_hipe",
+        "convert_hipe",
+        "HIPE",
+    ),
+    "iawe": ConverterSpec(
+        "nilmtk.dataset_converters.iawe.convert_iawe",
+        "convert_iawe",
+        "iAWE",
+    ),
+    "ideal": ConverterSpec(
+        "nilmtk.dataset_converters.ideal.convert_ideal",
+        "convert_ideal",
+        "IDEAL",
+    ),
+    "redd": ConverterSpec(
+        "nilmtk.dataset_converters.redd.convert_redd",
+        "convert_redd",
+        "REDD",
+    ),
+    "refit": ConverterSpec(
+        "nilmtk.dataset_converters.refit.convert_refit",
+        "convert_refit",
+        "REFIT",
+    ),
+    "smart": ConverterSpec(
+        "nilmtk.dataset_converters.smart.convert_smart",
+        "convert_smart",
+        "SMART",
+    ),
+    "ukdale": ConverterSpec(
+        "nilmtk.dataset_converters.ukdale.convert_ukdale",
+        "convert_ukdale",
+        "UK-DALE",
+    ),
+}
+
+PROGRAMMATIC_ONLY = {
+    "caxe": "writes a fixed output and requires dataset-specific metadata layout",
+    "dataport": "requires one or more CSV files plus a metadata directory",
+    "deddiag": "requires a live database connection",
+    "eco": "requires an explicit dataset timezone",
+    "greend": "has dataset-specific multiprocessing controls",
+}
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="nilmtk-convert",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        description=(
+            "Convert a supported raw energy dataset into a NILMTK datastore. "
+            "Use 'nilmtk-convert list' to see CLI and programmatic converters."
+        ),
+        epilog=(
+            "Start here:\n"
+            "  nilmtk-convert list\n"
+            "  nilmtk-convert redd /path/to/low_freq /path/to/redd.h5"
+        ),
+    )
+    parser.add_argument("--version", action="version", version=f"%(prog)s {version}")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    subparsers.add_parser("list", help="list available dataset converters")
+    for name, spec in CONVERTERS.items():
+        command = subparsers.add_parser(
+            name,
+            help=f"convert {spec.description} data",
+            description=f"Convert {spec.description} data to a NILMTK datastore.",
+        )
+        command.add_argument(
+            "input_path", type=Path, help="raw dataset file or directory"
+        )
+        command.add_argument(
+            "output_path", type=Path, help="destination datastore path"
+        )
+        command.add_argument(
+            "--format",
+            choices=("HDF", "CSV"),
+            default="HDF",
+            help="destination datastore format (default: HDF)",
+        )
+        command.add_argument(
+            "--force",
+            action="store_true",
+            help="allow replacement of an existing destination",
+        )
+    return parser
+
+
+def _print_converter_list() -> None:
+    print("Command-line converters:")
+    for name, spec in CONVERTERS.items():
+        print(f"  {name:<10} {spec.description}")
+    print("\nProgrammatic converters:")
+    for name, reason in PROGRAMMATIC_ONLY.items():
+        print(f"  {name:<10} {reason}")
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    if args.command == "list":
+        _print_converter_list()
+        return 0
+
+    input_path = args.input_path.expanduser()
+    output_path = args.output_path.expanduser()
+    if not input_path.exists():
+        parser.error(f"input path does not exist: {input_path}")
+    if input_path.resolve() == output_path.resolve():
+        parser.error("input and output paths must be different")
+    if output_path.exists() and not args.force:
+        parser.error(
+            f"output already exists (pass --force to replace it): {output_path}"
+        )
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    spec = CONVERTERS[args.command]
+    try:
+        module = importlib.import_module(spec.module)
+    except ImportError as error:
+        parser.exit(1, f"nilmtk-convert: could not load {args.command}: {error}\n")
+    converter = getattr(module, spec.function)
+    converter(str(input_path), str(output_path), format=args.format)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/nilmtk/dataset_converters/cli.py
+++ b/nilmtk/dataset_converters/cli.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import argparse
 import importlib
+import shutil
+import tempfile
 from collections.abc import Sequence
 from dataclasses import dataclass
 from pathlib import Path
@@ -138,6 +140,52 @@ def _print_converter_list() -> None:
         print(f"  {name:<10} {reason}")
 
 
+def _validate_paths(
+    parser: argparse.ArgumentParser,
+    input_path: Path,
+    output_path: Path,
+    output_format: str,
+    force: bool,
+) -> None:
+    if not input_path.exists():
+        parser.error(f"input path does not exist: {input_path}")
+
+    resolved_input = input_path.resolve()
+    resolved_output = output_path.resolve()
+    if resolved_input == resolved_output:
+        parser.error("input and output paths must be different")
+    if input_path.is_dir() and resolved_output.is_relative_to(resolved_input):
+        parser.error("output path must not be inside the input directory")
+    if output_path.is_dir() and resolved_input.is_relative_to(resolved_output):
+        parser.error("input path must not be inside the output directory")
+
+    if not output_path.exists():
+        return
+    protected_paths = {
+        Path(resolved_output.anchor),
+        Path.cwd().resolve(),
+        Path.home().resolve(),
+        Path(tempfile.gettempdir()).resolve(),
+    }
+    if force and resolved_output in protected_paths:
+        parser.error(f"refusing to replace protected path: {output_path}")
+    if output_format == "HDF" and output_path.is_dir():
+        parser.error("HDF output path must be a file, not a directory")
+    if output_format == "CSV" and not output_path.is_dir():
+        parser.error("CSV output path must be a directory, not a file")
+    if not force:
+        parser.error(
+            f"output already exists (pass --force to replace it): {output_path}"
+        )
+
+
+def _remove_existing_output(output_path: Path) -> None:
+    if output_path.is_symlink() or output_path.is_file():
+        output_path.unlink()
+    elif output_path.is_dir():
+        shutil.rmtree(output_path)
+
+
 def main(argv: Sequence[str] | None = None) -> int:
     parser = build_parser()
     args = parser.parse_args(argv)
@@ -148,15 +196,7 @@ def main(argv: Sequence[str] | None = None) -> int:
 
     input_path = args.input_path.expanduser()
     output_path = args.output_path.expanduser()
-    if not input_path.exists():
-        parser.error(f"input path does not exist: {input_path}")
-    if input_path.resolve() == output_path.resolve():
-        parser.error("input and output paths must be different")
-    if output_path.exists() and not args.force:
-        parser.error(
-            f"output already exists (pass --force to replace it): {output_path}"
-        )
-    output_path.parent.mkdir(parents=True, exist_ok=True)
+    _validate_paths(parser, input_path, output_path, args.format, args.force)
 
     spec = CONVERTERS[args.command]
     try:
@@ -164,6 +204,13 @@ def main(argv: Sequence[str] | None = None) -> int:
     except ImportError as error:
         parser.exit(1, f"nilmtk-convert: could not load {args.command}: {error}\n")
     converter = getattr(module, spec.function)
+
+    if args.force:
+        try:
+            _remove_existing_output(output_path)
+        except OSError as error:
+            parser.exit(1, f"nilmtk-convert: could not replace output: {error}\n")
+    output_path.parent.mkdir(parents=True, exist_ok=True)
     converter(str(input_path), str(output_path), format=args.format)
     return 0
 

--- a/nilmtk/version.py
+++ b/nilmtk/version.py
@@ -1,2 +1,2 @@
-version = '0.4.0.dev1+git.1b324df'
-short_version = '0.4.0'
+version = "0.4.1"
+short_version = "0.4.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,6 +91,8 @@ target-version = ['py311']
 [tool.ruff]
 target-version = "py311"
 line-length = 88
+
+[tool.ruff.lint]
 select = ["E", "F", "UP", "B", "SIM", "I"]
 
 [tool.pytest.ini_options]

--- a/scripts/check_docs.py
+++ b/scripts/check_docs.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+"""Check NILMTK's public onboarding and installation contract."""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+from urllib.parse import unquote, urlsplit
+
+ROOT = Path(__file__).resolve().parents[1]
+DOCUMENTS = (
+    ROOT / "README.md",
+    ROOT / "docs/manual/user_guide/install_user.md",
+    ROOT / "docs/manual/user_guide/install_dev.md",
+)
+
+REQUIRED_README_TEXT = (
+    "https://nilmtk.github.io/",
+    "https://github.com/nilmtk/nilm_metadata",
+    "https://github.com/nilmtk/nilmtk-contrib",
+    "https://github.com/nilmtk/nilmbench",
+    "https://nilmtk.github.io/nilmtk/master/index.html",
+    "10.1145/2602044.2602051",
+    "10.1109/COMPSACW.2014.97",
+    "10.1145/3360322.3360844",
+    "10.1145/3744256.3812587",
+    '"nilmtk[deddiag] @ git+https://github.com/nilmtk/nilmtk.git"',
+    (
+        "NILMTK core is a Python library and does not publish a separate "
+        "official core image."
+    ),
+)
+
+FORBIDDEN_INSTALL_COMMANDS = (
+    re.compile(r"^\s*conda\s+install\s+-c\s+nilmtk\b", re.MULTILINE),
+    re.compile(r"^\s*python\s+setup\.py\s+develop\b", re.MULTILINE),
+    re.compile(r"^\s*nosetests\s*$", re.MULTILINE),
+)
+
+MARKDOWN_LINK = re.compile(r"\[[^\]]+\]\(([^)]+)\)")
+
+
+def check_relative_links(document: Path, source: str, errors: list[str]) -> int:
+    count = 0
+    for raw_target in MARKDOWN_LINK.findall(source):
+        target = raw_target.split(maxsplit=1)[0].strip("<>")
+        parsed = urlsplit(target)
+        if (
+            parsed.scheme
+            or parsed.netloc
+            or target.startswith(("#", "mailto:", "tel:"))
+        ):
+            continue
+        path = (document.parent / unquote(parsed.path)).resolve()
+        count += 1
+        if not path.exists():
+            errors.append(
+                f"{document.relative_to(ROOT)} has a missing local link: {target}"
+            )
+    return count
+
+
+def main() -> int:
+    errors: list[str] = []
+    checked_links = 0
+
+    for document in DOCUMENTS:
+        source = document.read_text(encoding="utf-8")
+        if source.count("```") % 2:
+            errors.append(f"{document.relative_to(ROOT)} has an unclosed code fence")
+        if "http://" in source:
+            errors.append(f"{document.relative_to(ROOT)} contains an insecure URL")
+        if "ghcr.io/enfuego27826" in source:
+            errors.append(f"{document.relative_to(ROOT)} advertises a personal image")
+        for pattern in FORBIDDEN_INSTALL_COMMANDS:
+            if pattern.search(source):
+                errors.append(
+                    f"{document.relative_to(ROOT)} contains retired install command: "
+                    f"{pattern.pattern}"
+                )
+        checked_links += check_relative_links(document, source, errors)
+
+    readme = DOCUMENTS[0].read_text(encoding="utf-8")
+    normalized_readme = " ".join(readme.split())
+    for required in REQUIRED_README_TEXT:
+        if required not in normalized_readme:
+            errors.append(f"README.md is missing required contract text: {required}")
+
+    pyproject = (ROOT / "pyproject.toml").read_text(encoding="utf-8")
+    if 'requires-python = ">=3.11"' not in pyproject:
+        errors.append("pyproject.toml no longer matches the documented Python floor")
+    if 'nilmtk-convert = "nilmtk.dataset_converters.cli:main"' not in pyproject:
+        errors.append(
+            "pyproject.toml no longer defines the documented converter command"
+        )
+    if not (ROOT / "nilmtk/dataset_converters/cli.py").is_file():
+        errors.append("the documented converter entry point module does not exist")
+
+    if errors:
+        print("Documentation checks failed:", file=sys.stderr)
+        for error in errors:
+            print(f"- {error}", file=sys.stderr)
+        return 1
+
+    print(
+        f"Documentation checks passed: {len(DOCUMENTS)} documents, "
+        f"{checked_links} local links, {len(REQUIRED_README_TEXT)} contract clauses."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_converter_cli.py
+++ b/tests/test_converter_cli.py
@@ -1,0 +1,105 @@
+from types import SimpleNamespace
+
+import pytest
+
+from nilmtk.dataset_converters import cli
+
+
+def test_list_is_explicit_about_cli_and_programmatic_converters(capsys):
+    assert cli.main(["list"]) == 0
+
+    output = capsys.readouterr().out
+    assert "Command-line converters:" in output
+    assert "redd" in output
+    assert "ukdale" in output
+    assert "Programmatic converters:" in output
+    assert "deddiag" in output
+    assert "live database connection" in output
+
+
+def test_help_and_version_exit_successfully(capsys):
+    with pytest.raises(SystemExit) as help_exit:
+        cli.main(["--help"])
+    assert help_exit.value.code == 0
+    assert "nilmtk-convert list" in capsys.readouterr().out
+
+    with pytest.raises(SystemExit) as version_exit:
+        cli.main(["--version"])
+    assert version_exit.value.code == 0
+    assert "nilmtk-convert" in capsys.readouterr().out
+
+
+def test_missing_input_is_rejected_before_import(tmp_path, monkeypatch, capsys):
+    imported = False
+
+    def unexpected_import(_name):
+        nonlocal imported
+        imported = True
+
+    monkeypatch.setattr(cli.importlib, "import_module", unexpected_import)
+    with pytest.raises(SystemExit) as exit_info:
+        cli.main(["redd", str(tmp_path / "missing"), str(tmp_path / "out.h5")])
+
+    assert exit_info.value.code == 2
+    assert not imported
+    assert "input path does not exist" in capsys.readouterr().err
+
+
+def test_existing_output_requires_force(tmp_path, monkeypatch, capsys):
+    source = tmp_path / "raw"
+    source.mkdir()
+    output = tmp_path / "redd.h5"
+    output.write_text("keep", encoding="utf-8")
+    monkeypatch.setattr(
+        cli.importlib,
+        "import_module",
+        lambda _name: pytest.fail("converter imported before overwrite validation"),
+    )
+
+    with pytest.raises(SystemExit) as exit_info:
+        cli.main(["redd", str(source), str(output)])
+
+    assert exit_info.value.code == 2
+    assert output.read_text(encoding="utf-8") == "keep"
+    assert "--force" in capsys.readouterr().err
+
+
+def test_dispatch_is_lazy_and_forwards_normalized_arguments(tmp_path, monkeypatch):
+    source = tmp_path / "raw"
+    source.mkdir()
+    output = tmp_path / "nested" / "redd.csv"
+    calls = []
+
+    def convert_redd(input_path, output_path, format):
+        calls.append((input_path, output_path, format))
+
+    imported = []
+
+    def fake_import(name):
+        imported.append(name)
+        return SimpleNamespace(convert_redd=convert_redd)
+
+    monkeypatch.setattr(cli.importlib, "import_module", fake_import)
+
+    assert cli.main(["redd", str(source), str(output), "--format", "CSV"]) == 0
+    assert imported == ["nilmtk.dataset_converters.redd.convert_redd"]
+    assert calls == [(str(source), str(output), "CSV")]
+    assert output.parent.is_dir()
+
+
+@pytest.mark.parametrize("name", sorted(cli.CONVERTERS))
+def test_registry_points_to_a_specific_converter_function(name):
+    spec = cli.CONVERTERS[name]
+    assert spec.module.startswith(f"nilmtk.dataset_converters.{name}.")
+    assert spec.function == f"convert_{name}"
+
+
+def test_input_and_output_cannot_be_the_same_path(tmp_path, capsys):
+    path = tmp_path / "dataset"
+    path.mkdir()
+
+    with pytest.raises(SystemExit) as exit_info:
+        cli.main(["redd", str(path), str(path), "--force"])
+
+    assert exit_info.value.code == 2
+    assert "must be different" in capsys.readouterr().err

--- a/tests/test_converter_cli.py
+++ b/tests/test_converter_cli.py
@@ -1,3 +1,5 @@
+import tempfile
+from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
@@ -103,3 +105,111 @@ def test_input_and_output_cannot_be_the_same_path(tmp_path, capsys):
 
     assert exit_info.value.code == 2
     assert "must be different" in capsys.readouterr().err
+
+
+def test_force_clears_existing_csv_directory_before_dispatch(tmp_path, monkeypatch):
+    source = tmp_path / "raw"
+    source.mkdir()
+    output = tmp_path / "converted"
+    output.mkdir()
+    stale = output / "stale-meter.csv"
+    stale.write_text("old", encoding="utf-8")
+
+    def convert_redd(_input_path, output_path, format):
+        assert format == "CSV"
+        assert not Path(output_path).exists()
+
+    monkeypatch.setattr(
+        cli.importlib,
+        "import_module",
+        lambda _name: SimpleNamespace(convert_redd=convert_redd),
+    )
+
+    assert (
+        cli.main(
+            ["redd", str(source), str(output), "--format", "CSV", "--force"]
+        )
+        == 0
+    )
+    assert not stale.exists()
+
+
+def test_failed_import_preserves_existing_forced_output(tmp_path, monkeypatch, capsys):
+    source = tmp_path / "raw"
+    source.mkdir()
+    output = tmp_path / "redd.h5"
+    output.write_text("keep", encoding="utf-8")
+
+    def fail_import(_name):
+        raise ImportError("missing optional dependency")
+
+    monkeypatch.setattr(cli.importlib, "import_module", fail_import)
+    with pytest.raises(SystemExit) as exit_info:
+        cli.main(["redd", str(source), str(output), "--force"])
+
+    assert exit_info.value.code == 1
+    assert output.read_text(encoding="utf-8") == "keep"
+    assert "missing optional dependency" in capsys.readouterr().err
+
+
+def test_output_cannot_be_nested_inside_input(tmp_path, capsys):
+    source = tmp_path / "raw"
+    source.mkdir()
+
+    with pytest.raises(SystemExit) as exit_info:
+        cli.main(["redd", str(source), str(source / "converted.h5")])
+
+    assert exit_info.value.code == 2
+    assert "inside the input directory" in capsys.readouterr().err
+
+
+def test_force_refuses_to_replace_shared_temporary_directory(capsys):
+    with pytest.raises(SystemExit) as exit_info:
+        cli.main(
+            [
+                "redd",
+                str(Path.home()),
+                tempfile.gettempdir(),
+                "--format",
+                "CSV",
+                "--force",
+            ]
+        )
+
+    assert exit_info.value.code == 2
+    assert "protected path" in capsys.readouterr().err
+
+
+@pytest.mark.parametrize(
+    ("output_format", "make_output", "expected"),
+    [
+        ("HDF", lambda path: path.mkdir(), "must be a file"),
+        (
+            "CSV",
+            lambda path: path.write_text("wrong", encoding="utf-8"),
+            "directory",
+        ),
+    ],
+)
+def test_existing_output_type_must_match_format(
+    tmp_path, capsys, output_format, make_output, expected
+):
+    source = tmp_path / "raw"
+    source.mkdir()
+    output = tmp_path / "converted"
+    make_output(output)
+
+    with pytest.raises(SystemExit) as exit_info:
+        cli.main(
+            [
+                "redd",
+                str(source),
+                str(output),
+                "--format",
+                output_format,
+                "--force",
+            ]
+        )
+
+    assert exit_info.value.code == 2
+    assert expected in capsys.readouterr().err

--- a/tests/test_packaging_contracts.py
+++ b/tests/test_packaging_contracts.py
@@ -1,5 +1,8 @@
 import tomllib
+from importlib.metadata import version as installed_version
 from pathlib import Path
+
+import nilmtk
 
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
 NILM_METADATA_REQUIREMENT = (
@@ -18,3 +21,7 @@ def test_nilm_metadata_is_pinned_to_an_immutable_commit():
         if requirement.partition(" @ ")[0].replace("_", "-") == "nilm-metadata"
     ]
     assert matching == [NILM_METADATA_REQUIREMENT]
+
+
+def test_runtime_version_matches_package_metadata():
+    assert nilmtk.__version__ == installed_version("nilmtk")


### PR DESCRIPTION
## What changes

- replaces stale Python 3.6/Conda/setup.py onboarding with one Python 3.11 + uv path
- states which NILMTK repository to use for core data work, metadata, models, and benchmarks
- implements the advertised `nilmtk-convert` entry point with lazy converter loading, input/output overlap and type guards, protected-path refusal, clean CSV replacement, import-before-delete ordering, and discoverable CLI/programmatic converter lists
- makes the installed/runtime version consistently report 0.4.1 and closes the global temporary stats store at process exit
- adds a documentation/package CI contract so old commands, personal images, missing links, or a missing CLI cannot silently return
- moves Ruff's `select` setting to its current configuration table

## Verification

- `uv run --python 3.11 pytest -q` — 25 passed
- `uv run --python 3.11 ruff check ...` — passed
- `python3 scripts/check_docs.py` — 3 documents, 4 local links, 11 contract clauses passed
- `uv build` — sdist and wheel built
- clean Python 3.11 wheel install — import reported `0.4.1`; `nilmtk-convert --help` and `nilmtk-convert list` both exited 0
- `git diff --check` — passed

## Legacy-suite audit

I also bypassed the existing `testpaths = ["tests"]` setting and ran `tests`, `nilmtk/tests`, and `nilmtk/stats/tests` together: 59 passed and 9 failed. All 9 failures converge on the same pre-existing stale HDF fixture incompatibility (`pandas 2.2` receives serialized index metadata as `numpy.bytes_`). This PR does not conceal that result or expand into a binary-fixture migration; the docs now distinguish the current package gate from those historical regression directories. Test discovery and fixture regeneration should be the next small core-hardening PR.
