### PR TITLE
Clean up temporary HDF datastores deterministically

### DIFF
--- a/nilmtk/datastore/tmpdatastore.py
+++ b/nilmtk/datastore/tmpdatastore.py
@@ -1,5 +1,6 @@
 import os
 import tempfile
+from contextlib import suppress
 
 from nilmtk.datastore import HDFDataStore
 from nilmtk.docinherit import doc_inherit
@@ -7,13 +8,32 @@ from nilmtk.docinherit import doc_inherit
 
 class TmpDataStore(HDFDataStore):
     def __init__(self):
-        """ Create a `HDFDataStore` in the OS temporary directory in append mode.
-            The created HDF file will remain on the disk until a call to the `close()` method.
+        """Create an HDF datastore that is removed when it is closed.
+
+        The descriptor returned by :func:`tempfile.mkstemp` is closed before
+        PyTables opens the path. This avoids leaking one descriptor per store
+        and permits the file to be reopened on Windows.
         """
-        _, tmp_path = tempfile.mkstemp(suffix=".h5", prefix="nilmtk-")
+        descriptor, tmp_path = tempfile.mkstemp(suffix=".h5", prefix="nilmtk-")
         self.full_path = tmp_path
-        super().__init__(filename=self.full_path, mode="a")
+        try:
+            os.close(descriptor)
+            super().__init__(filename=self.full_path, mode="a")
+        except BaseException:
+            store = getattr(self, "store", None)
+            if store is not None:
+                with suppress(Exception):
+                    store.close()
+            self._remove_file()
+            raise
 
     @doc_inherit
     def close(self):
-        self.store.close()
+        try:
+            super().close()
+        finally:
+            self._remove_file()
+
+    def _remove_file(self):
+        with suppress(FileNotFoundError):
+            os.remove(self.full_path)

--- a/tests/test_tmp_datastore_lifecycle.py
+++ b/tests/test_tmp_datastore_lifecycle.py
@@ -1,0 +1,102 @@
+import os
+import subprocess
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+import nilmtk.datastore.tmpdatastore as tmpdatastore_module
+from nilmtk.datastore import HDFDataStore, TmpDataStore
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_tmp_datastore_releases_creation_descriptor_and_removes_file(
+    monkeypatch, tmp_path
+):
+    path = tmp_path / "cache.h5"
+    descriptor = os.open(path, os.O_CREAT | os.O_EXCL | os.O_RDWR)
+    closed_descriptors = []
+
+    class RecordingOS:
+        @staticmethod
+        def close(value):
+            closed_descriptors.append(value)
+            os.close(value)
+
+        @staticmethod
+        def remove(value):
+            os.remove(value)
+
+    monkeypatch.setattr(
+        tmpdatastore_module,
+        "tempfile",
+        SimpleNamespace(mkstemp=lambda **_kwargs: (descriptor, str(path))),
+    )
+    monkeypatch.setattr(tmpdatastore_module, "os", RecordingOS)
+
+    store = TmpDataStore()
+    try:
+        assert closed_descriptors == [descriptor]
+        assert path.exists()
+    finally:
+        store.close()
+    store.close()
+
+    assert not path.exists()
+
+
+def test_tmp_datastore_removes_file_when_hdf_initialization_fails(
+    monkeypatch, tmp_path
+):
+    path = tmp_path / "failed-cache.h5"
+    descriptor = os.open(path, os.O_CREAT | os.O_EXCL | os.O_RDWR)
+    monkeypatch.setattr(
+        tmpdatastore_module,
+        "tempfile",
+        SimpleNamespace(mkstemp=lambda **_kwargs: (descriptor, str(path))),
+    )
+    partial_store = SimpleNamespace(closed=False)
+
+    def close_partial_store():
+        partial_store.closed = True
+
+    partial_store.close = close_partial_store
+
+    def fail_initialization(store, *_args, **_kwargs):
+        with pytest.raises(OSError):
+            os.fstat(descriptor)
+        store.store = partial_store
+        raise RuntimeError("simulated HDF initialization failure")
+
+    monkeypatch.setattr(HDFDataStore, "__init__", fail_initialization)
+
+    with pytest.raises(RuntimeError, match="simulated HDF initialization failure"):
+        TmpDataStore()
+
+    assert partial_store.closed
+    assert not path.exists()
+
+
+def test_process_exit_closes_and_removes_shared_stats_cache(tmp_path):
+    environment = os.environ.copy()
+    environment["MPLCONFIGDIR"] = str(tmp_path / "matplotlib")
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-W",
+            "always",
+            "-c",
+            "import nilmtk; print(nilmtk.STATS_CACHE.full_path)",
+        ],
+        cwd=ROOT,
+        env=environment,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "UnclosedFileWarning" not in result.stderr
+    assert not Path(result.stdout.strip()).exists()


### PR DESCRIPTION
## Summary
- close the descriptor returned by mkstemp before PyTables opens the temporary HDF path
- remove the temporary file on normal close and on partial constructor failure
- keep close idempotent so explicit cleanup and the process-wide atexit callback can safely coexist

## Regression coverage
The three new lifecycle tests fail against master and verify:
- the creation descriptor is released before HDF initialization
- a partially initialized HDF store is closed and its artifact removed
- interpreter exit removes the shared STATS_CACHE file without UnclosedFileWarning

## Verification
- full modern and legacy suite: 81 passed
- focused datastore and dataset lifecycle suite: 19 passed
- changed-file Ruff checks passed
- documentation contracts passed
- source distribution and wheel built
- git diff check passed